### PR TITLE
Various Updates and Fixes for vs2017-windows branch.

### DIFF
--- a/h5cpp/H5Dwrite.hpp
+++ b/h5cpp/H5Dwrite.hpp
@@ -85,7 +85,13 @@ namespace h5 {
 			std::vector<char*> ptr;
 			try {
 				for( const auto& reference:ref)
-            		ptr.push_back( strdup( reference.data()) );
+					#ifdef _MSC_VER
+						// Visual Studio 2017 complains:
+						// Error C4996 'strdup': The POSIX name for this item is deprecated. Instead, use the ISO C and C++ conformant name: _strdup.
+						ptr.push_back( _strdup(reference.data()) );
+					#else
+						ptr.push_back( strdup( reference.data()) );
+					#endif
 			} catch( ... ){
 				throw h5::error::io::dataset::write( h5::error::msg::mem_alloc );
 			}

--- a/h5cpp/H5Zpipeline.hpp
+++ b/h5cpp/H5Zpipeline.hpp
@@ -149,7 +149,12 @@ inline void h5::impl::pipeline_t<Derived>::set_cache( const h5::dcpl_t& dcpl, si
 }
 
 #define h5cpp_outer( idx ) for( j##idx =0; j##idx < n##idx; j##idx += b##idx)
+#ifdef _MSC_VER
+// Observe std::min is wrapped in ().
+#define h5cpp_inner( idx ) for( i##idx = j##idx; i##idx < (std::min)(j##idx+b##idx,n##idx); i##idx++)
+#else
 #define h5cpp_inner( idx ) for( i##idx = j##idx; i##idx < std::min(j##idx+b##idx,n##idx); i##idx++)
+#endif // _MSC_VER
 #define h5cpp_def( idx ) hsize_t i##idx=0, j##idx = 0, s##idx=0, n##idx=N[idx], b##idx=B[idx], rx##idx=Rx[idx],  ry##idx=Ry[idx];
 
 template< class Derived>

--- a/h5cpp/H5capi.hpp
+++ b/h5cpp/H5capi.hpp
@@ -6,7 +6,7 @@
 
 #ifndef  H5CPP_CAPI_HPP
 #define  H5CPP_CAPI_HPP
-#include <limits>
+
 /* rules:
  * h5::id_t{ hid_t } or direct initialization  doesn't increment reference count
  */ 

--- a/h5cpp/H5capi.hpp
+++ b/h5cpp/H5capi.hpp
@@ -6,7 +6,7 @@
 
 #ifndef  H5CPP_CAPI_HPP
 #define  H5CPP_CAPI_HPP
-
+#include <limits>
 /* rules:
  * h5::id_t{ hid_t } or direct initialization  doesn't increment reference count
  */ 
@@ -214,7 +214,12 @@ inline std::ostream& operator<<(std::ostream& os, const h5::impl::array<T>& arr)
 	if( arr.rank )
 		for(int i=0;i<arr.rank; i++){
 			char sep = i != arr.rank - 1  ? ',' : '}';
-			if( arr[i] < std::numeric_limits<hsize_t>::max() )
+#ifdef _MSC_VER
+// Observe std::numeric_limits<hsize_t>::max is wrapped in ().
+			if( arr[i] < (std::numeric_limits<hsize_t>::max)() )
+#else
+			if (arr[i] < std::numeric_limits<hsize_t>::max())
+#endif // _MSC_VER
 				os << arr[i] << sep;
 			else
 				os << "inf" << sep;


### PR DESCRIPTION
Incorporates fix for Visual Studio 2017 reporting:
Error C4996 'strdup': The POSIX name for this item is deprecated. Instead, use the ISO C and C++ conformant name: _strdup.

Uses _MSC_VER to identify Visual Studio compiler.

Also fixes compilation errors when windows.h is included before h5cpp/all. See issue: https://github.com/steven-varga/h5cpp/issues/21

Also properly implements `_aligned_free` for `_aligned_alloc`.