### PR TITLE
Incorporate h5::append fille_value fixes for MSVC

### DIFF
--- a/h5cpp/H5Zpipeline_basic.hpp
+++ b/h5cpp/H5Zpipeline_basic.hpp
@@ -10,21 +10,26 @@
 
 inline void h5::impl::basic_pipeline_t::write_chunk_impl( const hsize_t* offset, size_t nbytes, const void* data ){
 
-	size_t length = nbytes; // filter may changed this, think of compression
+	size_t length = nbytes;                        // filter may change this, think of compression
 	void *in = chunk0, *out=chunk1, *tmp = chunk0; // invariant: out must point to data block written
+	uint32_t mask = 0x0;                           // filter mask = 0x0 all filters applied
 	switch( tail ){ // tail = index pointing to queue holding filters
 		case 0: // no filters, ( if blocking ) -> data == chunk0 otherwise directly from container 
 			H5Dwrite_chunk( ds, dxpl, 0x0, offset, nbytes, data);
 			break;
 		case 1: // single filter
-			length = filter[0](out, data, nbytes, flags[0], cd_size[0], cd_values[0] );
+			length = filter[0](out, data, nbytes, flags[0], cd_size[0], cd_values[0] ) ;
+			if( !length )
+				mask = 1 << 0;
 		default: // more than one filter
 			for(int j=1; j<tail; j++){ // invariant: out == buffer holding final result
 				tmp = in, in = out, out = tmp;
 				length = filter[j](out,in,length, flags[j], cd_size[j], cd_values[j]);
+				if( !length )
+					mask |= 1 << j;
 			}
 			// direct write available from > 1.10.4
-			H5Dwrite_chunk(ds, dxpl, 0, offset, length, out);
+			H5Dwrite_chunk(ds, dxpl, mask, offset, length, out);
 	}
 }
 
@@ -48,11 +53,11 @@ inline void h5::impl::basic_pipeline_t::read_chunk_impl( const hsize_t* offset, 
 		default: // more than one filter
 			throw std::runtime_error("filters not implemented yet...");
 			if( tail % 2 ){
-			H5Dread_chunk(ds, dxpl, offset, &filter_mask, chunk0);
-			for(int j=tail; j>0; j--){ // invariant: out == buffer holding final result
-				tmp = in, in = out, out = tmp;
-				length = filter[j](out,in,length, flags[j], cd_size[j], cd_values[j]);
-			}
+				H5Dread_chunk(ds, dxpl, offset, &filter_mask, chunk0);
+				for(int j=tail; j>0; j--){ // invariant: out == buffer holding final result
+					tmp = in, in = out, out = tmp;
+					length = filter[j](out,in,length, flags[j], cd_size[j], cd_values[j]);
+				}
 			}
 			// direct write available from > 1.10.4
 	}

--- a/h5cpp/H5capi.hpp
+++ b/h5cpp/H5capi.hpp
@@ -7,6 +7,8 @@
 #ifndef  H5CPP_CAPI_HPP
 #define  H5CPP_CAPI_HPP
 
+
+
 /* rules:
  * h5::id_t{ hid_t } or direct initialization  doesn't increment reference count
  */ 
@@ -206,6 +208,28 @@ namespace h5 {
 		return ds_;
 	}
 
+	inline void * get_fill_value(const h5::dcpl_t& dcpl, const h5::dt_t<void*>& type, size_t size){
+
+		H5D_fill_value_t fill_value_status;
+		H5Pfill_value_defined(static_cast<::hid_t>(dcpl), &fill_value_status);
+
+		if( fill_value_status != H5D_FILL_VALUE_UNDEFINED ){
+			void * buffer = malloc(size);
+			H5Pget_fill_value(
+					static_cast<::hid_t>(dcpl),
+					static_cast<::hid_t>(type), buffer );
+			return buffer;
+		} else
+			return NULL;
+	}
+
+	inline void * get_fill_value(const h5::ds_t& ds){
+		h5::dt_t<void*> type = h5::get_type<void*>( ds );
+		hsize_t size = h5::get_size( type );
+		h5::dcpl_t dcpl = h5::get_dcpl( ds );
+
+		return h5::get_fill_value(dcpl, type, size);
+	}
 }
 #endif
 

--- a/h5cpp/core
+++ b/h5cpp/core
@@ -23,6 +23,7 @@
 #include <functional>
 #include <complex>
 #include <cstring>
+#include <stdlib.h>
 
 #ifdef H5CPP_WITH_GLOG
    #include <glog/logging.h>


### PR DESCRIPTION
Merge recent fix for h5::append fill_value to MSVC branch.

No MSVC-specific changes were required to the fixes.