### PR TITLE
Fix some compiler errors and warnings

### DIFF
--- a/h5cpp/H5Acreate.hpp
+++ b/h5cpp/H5Acreate.hpp
@@ -21,8 +21,8 @@ namespace h5 {
 	h5::at_t>::type create( const HID_T& parent, const std::string& path, args_t&&... args ){
 		try {
 			// compile time check of property lists: 
-			using tcurrent_dims = typename arg::tpos<const h5::current_dims_t&,const args_t&...>;
-			using tacpl 		= typename arg::tpos<const h5::acpl_t&,const args_t&...>;
+                        //using tcurrent_dims = typename arg::tpos<const h5::current_dims_t&,const args_t&...>;
+                        //using tacpl             = typename arg::tpos<const h5::acpl_t&,const args_t&...>;
 
 			h5::acpl_t default_acpl{ H5Pcreate(H5P_ATTRIBUTE_CREATE) };
 			const h5::acpl_t& acpl = arg::get(default_acpl, args...);
@@ -49,4 +49,3 @@ namespace h5 {
 
 }
 #endif
-

--- a/h5cpp/H5Aread.hpp
+++ b/h5cpp/H5Aread.hpp
@@ -67,7 +67,7 @@ namespace h5 {
 		h5::sp_t file_space{id};
 		h5::current_dims_t current_dims;
 		int rank = get_simple_extent_dims(file_space, current_dims );
-		using element_t = typename impl::decay<T>::type;
+                //using element_t = typename impl::decay<T>::type;
 		h5::dt_t<char*> type;
 		T object = impl::get<T>::ctor( current_dims );
         size_t nelem = impl::nelements(current_dims);
@@ -86,4 +86,3 @@ namespace h5 {
 
 }
 #endif
-

--- a/h5cpp/H5Dappend.hpp
+++ b/h5cpp/H5Dappend.hpp
@@ -41,7 +41,7 @@ namespace h5 {
 
             pt.ptr = nullptr; pt.fill_value = nullptr;
             pt.N=0; pt.n=0; pt.rank=0;
-		    for(int i=0; i<rank; i++){
+                    for(unsigned i=0; i<rank; i++){
 			    this->offset[i] = pt.offset[i];
                 this->current_dims[i] = pt.current_dims[i];
                 this->chunk_dims[i] = pt.chunk_dims[i];
@@ -81,7 +81,7 @@ namespace h5 {
 /* initialized to invalid state
  * */
 inline h5::pt_t::pt_t() :
-	dxpl{H5Pcreate(H5P_DATASET_XFER)},ds{H5I_UNINIT},n{0},fill_value{NULL}{
+        ds{H5I_UNINIT},dxpl{H5Pcreate(H5P_DATASET_XFER)},n{0},fill_value{NULL}{
 		for( int i=0; i<H5CPP_MAX_RANK; i++ )
 			count[i] = 1, offset[i] = 0;
 	}
@@ -122,7 +122,7 @@ void h5::pt_t::init( const h5::ds_t& handle ){
 		this->N = pipeline.n;
 		pipeline.ds = ds; pipeline.dxpl = dxpl;
 		h5::get_chunk_dims( dcpl, chunk_dims );
-		for(int i=1; i<rank; i++)
+                for(unsigned i=1; i<rank; i++)
 			current_dims[i] = chunk_dims[i];
 	} catch ( ... ){
 		throw h5::error::io::packet_table::misc( H5CPP_ERROR_MSG("CTOR: unable to create handle from dataset..."));
@@ -204,7 +204,7 @@ void h5::pt_t::flush(){
 			static_cast<char*>( ptr )[(n + i) * element_size + j] = static_cast<char*>( fill_value )[ j ];
 	*offset = *current_dims;
 	*current_dims += *current_dims % *chunk_dims;
-	size_t r=1; for(int i=1; i<rank; i++) r*=chunk_dims[i];
+        size_t r=1; for(unsigned i=1; i<rank; i++) r*=chunk_dims[i];
 	*current_dims += (n % r) ? n / r + 1 : n / r;
 	h5::set_extent(ds, current_dims);
     pipeline.write_chunk( offset, block_size, ptr );

--- a/h5cpp/H5Dcreate.hpp
+++ b/h5cpp/H5Dcreate.hpp
@@ -22,9 +22,9 @@ namespace h5 {
 		// compile time check of property lists: 
 		using tcurrent_dims = typename arg::tpos<const h5::current_dims_t&,const args_t&...>;
 		using tmax_dims 	= typename arg::tpos<const h5::max_dims_t&,const args_t&...>;
-		using tlcpl 		= typename arg::tpos<const h5::lcpl_t&,const args_t&...>;
+                //using tlcpl           = typename arg::tpos<const h5::lcpl_t&,const args_t&...>;
 		using tdcpl 		= typename arg::tpos<const h5::dcpl_t&,const args_t&...>;
-		using tdapl 		= typename arg::tpos<const h5::dapl_t&,const args_t&...>;
+                //using tdapl           = typename arg::tpos<const h5::dapl_t&,const args_t&...>;
 
 		//TODO: make copy of default dcpl
 		h5::dcpl_t default_dcpl{ H5Pcreate(H5P_DATASET_CREATE) };
@@ -82,4 +82,3 @@ namespace h5 {
 	}
 }
 #endif
-

--- a/h5cpp/H5Dopen.hpp
+++ b/h5cpp/H5Dopen.hpp
@@ -47,6 +47,7 @@ namespace h5{
 				}
 				break;
 			case H5D_VIRTUAL: break;
+                        default: {/* silence warning of unhandled enumeration values */}
 		}
 
 		h5::ds_t ds_{ds};
@@ -57,4 +58,3 @@ namespace h5{
 }
 
 #endif
-

--- a/h5cpp/H5Dread.hpp
+++ b/h5cpp/H5Dread.hpp
@@ -27,10 +27,10 @@ namespace h5 {
 	template<class T, class... args_t>
 	typename std::enable_if<!std::is_same<T,char**>::value,
 	void>::type read( const h5::ds_t& ds, T* ptr, args_t&&... args ) try {
-		using toffset  = typename arg::tpos<const h5::offset_t&,const args_t&...>;
-		using tstride  = typename arg::tpos<const h5::stride_t&,const args_t&...>;
+                //using toffset  = typename arg::tpos<const h5::offset_t&,const args_t&...>;
+                //using tstride  = typename arg::tpos<const h5::stride_t&,const args_t&...>;
 		using tcount   = typename arg::tpos<const h5::count_t&,const args_t&...>;
-		using tblock   = typename arg::tpos<const h5::block_t&,const args_t&...>;
+                //using tblock   = typename arg::tpos<const h5::block_t&,const args_t&...>;
 		static_assert( tcount::present, "h5::count_t{ ... } must be specified" );
 		static_assert( utils::is_supported<T>, "error: " H5CPP_supported_elementary_types );
 
@@ -239,10 +239,10 @@ namespace h5 {
 	// update the content by we're good to go, since stride and offset can be processed in the 
 	// update step
 		using tcount  = typename arg::tpos<const h5::count_t&,const args_t&...>;
-		using toffset  = typename arg::tpos<const h5::offset_t&,const args_t&...>;
-		using tstride  = typename arg::tpos<const h5::stride_t&,const args_t&...>;
-		using tblock   = typename arg::tpos<const h5::block_t&,const args_t&...>;
-		using element_type    = typename impl::decay<T>::type;
+                //using toffset  = typename arg::tpos<const h5::offset_t&,const args_t&...>;
+                //using tstride  = typename arg::tpos<const h5::stride_t&,const args_t&...>;
+                //using tblock   = typename arg::tpos<const h5::block_t&,const args_t&...>;
+                //using element_type    = typename impl::decay<T>::type;
 
 		h5::count_t size;
 		const h5::count_t& count = arg::get(size, args...);
@@ -270,7 +270,7 @@ namespace h5 {
 	   	int rank = h5::get_simple_extent_ndims( file_space );
 
 		if( rank != count.rank ) throw h5::error::io::dataset::read( H5CPP_ERROR_MSG( h5::error::msg::rank_mismatch ));
-		using element_t = typename impl::decay<T>::type;
+                //using element_t = typename impl::decay<T>::type;
 		h5::dt_t<char*> mem_type;
 		hid_t dapl = h5::get_access_plist( ds );
 

--- a/h5cpp/H5Dwrite.hpp
+++ b/h5cpp/H5Dwrite.hpp
@@ -73,7 +73,7 @@ namespace h5 {
 	h5::ds_t>::type write( const h5::ds_t& ds, const T& ref,   args_t&&... args  ) try {
 		// element types: pod | [signed|unsigned](int8 | int16 | int32 | int64) | float | double | std::string
 		using element_t = typename impl::decay<T>::type;
-		using tcount = typename arg::tpos<const h5::count_t&,const args_t&...>;
+                //using tcount = typename arg::tpos<const h5::count_t&,const args_t&...>;
 		h5::count_t default_count;
 
 		default_count = impl::size( ref );
@@ -107,8 +107,8 @@ namespace h5 {
 		using tcount  = typename arg::tpos<const h5::count_t&,const args_t&...>;
 		using toffset = typename arg::tpos<const h5::offset_t&,const args_t&...>;
 		using tstride = typename arg::tpos<const h5::stride_t&,const args_t&...>;
-		using tblock  = typename arg::tpos<const h5::block_t&,const args_t&...>;
-		using tdapl   = typename arg::tpos<const h5::dapl_t&,const args_t&...>;
+                //using tblock  = typename arg::tpos<const h5::block_t&,const args_t&...>;
+                //using tdapl   = typename arg::tpos<const h5::dapl_t&,const args_t&...>;
 		using tcurrent_dims = typename arg::tpos<const h5::current_dims_t&,const args_t&...>;
 
 		static_assert( tcount::present,"h5::count_t{ ... } must be provided to describe T* memory region" );
@@ -152,12 +152,12 @@ namespace h5 {
  	*/ 
 	template <class T, class... args_t>
 	h5::ds_t write( const h5::fd_t& fd, const std::string& dataset_path, const T& ref,  args_t&&... args  ){
-		using tcount  = typename arg::tpos<const h5::count_t&,const args_t&...>;
+                //using tcount  = typename arg::tpos<const h5::count_t&,const args_t&...>;
 		using toffset = typename arg::tpos<const h5::offset_t&,const args_t&...>;
 		using tstride = typename arg::tpos<const h5::stride_t&,const args_t&...>;
 		using tblock = typename arg::tpos<const h5::block_t&,const args_t&...>;
 		using tcurrent_dims = typename arg::tpos<const h5::current_dims_t&,const args_t&...>;
-		using tdapl   = typename arg::tpos<const h5::dapl_t&,const args_t&...>;
+                //using tdapl   = typename arg::tpos<const h5::dapl_t&,const args_t&...>;
 
 		int rank = impl::rank<T>::value;
 

--- a/h5cpp/H5Iall.hpp
+++ b/h5cpp/H5Iall.hpp
@@ -100,9 +100,9 @@ namespace h5 { namespace impl { namespace detail {
 			ref.handle = H5I_UNINIT;
 		}
 		~hid_t(){
-			::herr_t err = 0;
+                        /* ::herr_t err = 0; */
 			if( H5Iis_valid( handle ) )
-				err = capi_close( handle );
+                          /* err = */ capi_close( handle );
 		}
 		protected:
 		::hid_t handle;

--- a/h5cpp/H5Iall.hpp
+++ b/h5cpp/H5Iall.hpp
@@ -169,7 +169,7 @@ namespace h5 { namespace impl { namespace detail {
 		};
 
 		template <class V> at_t operator=( V arg  );
-		template <class V> at_t operator=( const std::initializer_list<V> args  ){};
+                template <class V> at_t operator=( const std::initializer_list<V> args  );
 
 		::hid_t ds;
 		std::string name;

--- a/h5cpp/H5Zall.hpp
+++ b/h5cpp/H5Zall.hpp
@@ -47,7 +47,7 @@ namespace h5 { namespace impl { namespace filter {
 	}
 	inline size_t gzip( void* dst, const void* src, size_t size, unsigned flags, size_t n, const unsigned params[]){
 		size_t nbytes = size;
-		int ret = compress2( (unsigned char*)dst, &nbytes, (const unsigned char*)src, size, params[0]);
+                /*int ret = */compress2( (unsigned char*)dst, &nbytes, (const unsigned char*)src, size, params[0]);
 		return nbytes;
 	}
 	inline size_t szip( void* dst, const void* src, size_t size, unsigned flags, size_t n, const unsigned params[]){

--- a/h5cpp/H5Zpipeline.hpp
+++ b/h5cpp/H5Zpipeline.hpp
@@ -115,7 +115,7 @@ inline void h5::impl::pipeline_t<Derived>::write(
 				const h5::dxpl_t& dxpl, const void* ptr){
 
 	h5::offset_t offset_; h5::count_t count_;
-	for(int i=0; i<rank; i++)
+        for(hsize_t i=0; i<rank; i++)
 		offset_[i] = offset[i], count_[i] = count[i] * block[i];
 	this->dxpl = dxpl; this->ds = ds;
 	split_to_chunk_write(filter_direction_t::forward, offset_.begin(), count_.begin(), ptr );
@@ -127,7 +127,7 @@ inline void h5::impl::pipeline_t<Derived>::read(
 				const h5::dxpl_t& dxpl, void* ptr){
 
 	h5::offset_t offset_; h5::count_t count_;
-	for(int i=0; i<rank; i++)
+        for(hsize_t i=0; i<rank; i++)
 		offset_[i] = offset[i], count_[i] = count[i] * block[i];
 	this->dxpl = dxpl; this->ds = ds;
 	split_to_chunk_read(filter_direction_t::reverse, offset_.begin(), count_.begin(), ptr );
@@ -143,13 +143,13 @@ inline void h5::impl::pipeline_t<Derived>::set_cache( const h5::dcpl_t& dcpl, si
 			throw std::runtime_error("data-space is rank 0, is data space a scalar? ");
 
 	//fix B block/chunk size for the lifespan of pipeline
-	for(int i=0; i<rank; i++ )
+        for(hsize_t i=0; i<rank; i++ )
 	   	n *= block[i], B[i] = block[rank-i-1];
 
 	block_size = n*element_size;
 	unsigned filter_config;
 	unsigned N = H5Pget_nfilters( dcpl );
-	H5Z_filter_t filter_id;
+        //H5Z_filter_t filter_id;
 	for(unsigned i=0; i<N; i++){
 		cd_size[i] = H5CPP_MAX_FILTER_PARAM;
 		push(
@@ -165,7 +165,7 @@ inline void h5::impl::pipeline_t<Derived>::set_cache( const h5::dcpl_t& dcpl, si
 
 #define h5cpp_outer( idx ) for( j##idx =0; j##idx < n##idx; j##idx += b##idx)
 #define h5cpp_inner( idx ) for( i##idx = j##idx; i##idx < std::min(j##idx+b##idx,n##idx); i##idx++)
-#define h5cpp_def( idx ) hsize_t i##idx=0, j##idx = 0, s##idx=0, n##idx=N[idx], b##idx=B[idx], rx##idx=Rx[idx],  ry##idx=Ry[idx];
+#define h5cpp_def( idx ) hsize_t i##idx [[maybe_unused]] =0, j##idx = 0, s##idx [[maybe_unused]] =0, n##idx=N[idx], b##idx=B[idx], rx##idx [[maybe_unused]] =Rx[idx], ry##idx [[maybe_unused]] =Ry[idx];
 
 template< class Derived>
 inline void h5::impl::pipeline_t<Derived>::split_to_chunk_read(
@@ -247,7 +247,7 @@ inline void h5::impl::pipeline_t<Derived>::split_to_chunk_write(
 		// the coordinates are in j indices
 		D[0] = j0, D[1]=j1, D[2]=j2, D[3]=j3, D[4]=j4, D[5]=j5, D[6]=j6;
 		//coordinates are reversed in D, invert them:
-		for(int k=0;k<rank; k++ ) C[k] = D[rank-k-1] + chunk_offset[k];
+                for(hsize_t k=0;k<rank; k++ ) C[k] = D[rank-k-1] + chunk_offset[k];
 
 		// execute filters in direction
 		write_chunk( this->C, this->block_size, this->chunk0 );

--- a/h5cpp/H5Zpipeline.hpp
+++ b/h5cpp/H5Zpipeline.hpp
@@ -272,5 +272,6 @@ inline std::ostream& operator<<(std::ostream &os, const h5::impl::pipeline_t<T>&
 	os <<"pipeline:\n"
 		 "------------------------------------------\n";
     os << "n: " << p.n;
+    return os;
 }
 #endif

--- a/h5cpp/H5Zpipeline_basic.hpp
+++ b/h5cpp/H5Zpipeline_basic.hpp
@@ -20,7 +20,7 @@ inline void h5::impl::basic_pipeline_t::write_chunk_impl( const hsize_t* offset,
 			if( !length )
 				mask = 1 << 0;
 		default: // more than one filter
-			for(int j=1; j<tail; j++){ // invariant: out == buffer holding final result
+                        for(hsize_t j=1; j<tail; j++){ // invariant: out == buffer holding final result
 				tmp = in, in = out, out = tmp;
 				length = filter[j](out,in,length, flags[j], cd_size[j], cd_values[j]);
 				if( !length )
@@ -52,7 +52,7 @@ inline void h5::impl::basic_pipeline_t::read_chunk_impl( const hsize_t* offset, 
 			throw std::runtime_error("filters not implemented yet...");
 			if( tail % 2 ){
 				H5Dread_chunk(ds, dxpl, offset, &filter_mask, chunk0);
-				for(int j=tail; j>0; j--){ // invariant: out == buffer holding final result
+                                for(hsize_t j=tail; j>0; j--){ // invariant: out == buffer holding final result
 					tmp = in, in = out, out = tmp;
 					length = filter[j](out,in,length, flags[j], cd_size[j], cd_values[j]);
 				}

--- a/h5cpp/H5capi.hpp
+++ b/h5cpp/H5capi.hpp
@@ -199,6 +199,7 @@ namespace h5 {
 				}
 				break;
 			case H5D_VIRTUAL: break;
+                        default: {/* silence warning of unhandled enumeration values */}
 		}
 		ds_.dapl = static_cast<::hid_t>( dapl );
 		return ds_;
@@ -228,4 +229,3 @@ namespace h5 {
 	}
 }
 #endif
-

--- a/h5cpp/H5cout.hpp
+++ b/h5cpp/H5cout.hpp
@@ -67,7 +67,7 @@ std::ostream& operator<<(std::ostream &os, const h5::sp_t& sp) {
 	h5::max_dims_t max_dims;
 	unsigned rank = h5::get_simple_extent_dims( sp, current_dims, max_dims);
 	hsize_t total_elements = H5Sget_simple_extent_npoints( id );
- 	herr_t err = H5Sget_select_bounds(id, *start, *end);
+        /*herr_t err = */H5Sget_select_bounds(id, *start, *end);
 	start.rank = end.rank = rank;
 	hsize_t nblocks =  H5Sget_select_hyper_nblocks( id );
 	hsize_t ncoordinates = 2*rank*nblocks;
@@ -81,10 +81,10 @@ std::ostream& operator<<(std::ostream &os, const h5::sp_t& sp) {
 	if( H5Sget_select_hyper_blocklist(id, 0, nblocks, buffer.get() ) >= 0   ){
 		os << "[selected block count]\t" << nblocks <<std::endl;
 		os << "[selected blocks]\t";
-		for( int i=0; i<nblocks; i++){
+                for( hsize_t i=0; i<nblocks; i++){
 			os << "[{";
-			for( int j=0; j<rank; j++) os << *( buffer.get() + i*2*rank+j ) << (j < rank-1 ? "," : "}{");
-			for( int j=rank; j<2*rank; j++) os << *( buffer.get() + i*2*rank+j ) << ( j < 2*rank-1 ? "," : "}");
+                        for( unsigned j=0; j<rank; j++) os << *( buffer.get() + i*2*rank+j ) << (j < rank-1 ? "," : "}{");
+                        for( unsigned j=rank; j<2*rank; j++) os << *( buffer.get() + i*2*rank+j ) << ( j < 2*rank-1 ? "," : "}");
 			os << "] ";
 		}
 	}
@@ -96,7 +96,7 @@ template <class T> inline
 std::ostream& operator<<(std::ostream& os, const std::vector<T>& vec){
 	os << "[";
 	if(vec.size() < H5CPP_CONSOLE_WIDTH ){
-		int i=0;
+                typename std::vector<T>::size_type i=0;
 		for(; i<vec.size()-1; i++ ) os << vec[i] <<",";
 		os << vec[i];
 	}else{
@@ -108,4 +108,3 @@ return os;
 
 
 #endif
-


### PR DESCRIPTION
As detected using GCC 8.2.  These changes address some sign-comparison, unused-variable, unused-type alias, and other minor warnings.

Sorry for some of the whitespace changes.  Let me know if you'd like me to reformat.