### PR TITLE
build, review and modernize cmake for C++17 and package exports

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,114 +1,139 @@
-#  _________________________________________________________
-#  Copyright (c) 2018-2020 Steven Varga, Toronto,ON Canada
-#  Author: Varga, Steven <steven@vargaconsulting.ca>
-#  _________________________________________________________
+# SPDX-License-Identifier: MIT
+# This file is part of H5CPP.
+# Copyright (c) 2025-2026 Varga Labs, Toronto, ON, Canada. 
 
 cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
-if(${CMAKE_VERSION} VERSION_GREATER "3.17.0")
-	cmake_policy(SET CMP0074 NEW)
+
+if(CMAKE_VERSION VERSION_GREATER "3.17.0")
+    cmake_policy(SET CMP0074 NEW)
 endif()
-## match hdf5 versioning x.x.x.h5cpp-version
+
 project(libh5cpp-dev VERSION 1.10.4.6 LANGUAGES CXX C)
+
+
+option(H5CPP_BUILD_EXAMPLES "Build examples" OFF)
+option(H5CPP_BUILD_TESTS    "Build tests"    OFF)
+
+# Generate compile_commands.json for clangd / VS Code / tooling
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 set(CMAKE_CXX_STANDARD 17)
-find_package( Threads REQUIRED QUIET)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
-add_library(h5cpp INTERFACE)
-# check if the correct version of hdf5 available
-set(H5CPP_VERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH})
-if(WIN32)
-	set(CMAKE_PREFIX_PATH  "C:/linalg"  "C:/linalg/lib"  "C:/linalg/lib/cmake"  "C:/linalg/share")
-	set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/"
-			"${CMAKE_SOURCE_DIR}/cmake/eigen3"  "${CMAKE_SOURCE_DIR}/cmake/dlib" )
-	set(ARMADILLO_LIBRARY_DIRS  "C:/linalg/bin")
+include(GNUInstallDirs)
 
-elseif(UNIX)
-	set(HDF5_ROOT /usr/local/ /usr) # there maybe more upto date library in these places
-	include(GNUInstallDirs)
-	find_package(PkgConfig REQUIRED QUIET)
-endif()
-if(APPLE)
-	message(STATUS "***WARNING: h5cpp is not fully tested on apple ***")
-endif()
-if(ANDROID)
-	message(STATUS "***WARNING: h5cpp is not fully tested on android ***")
-endif()
+find_package(Threads REQUIRED QUIET)
 
-include(FindHDF5)
-if(HDF5_VERSION VERSION_LESS ${H5CPP_VERSION})
-	message(FATAL_ERROR "-- !!! H5CPP examples require of HDF5 v${H5CPP_VERSION} or greater!!!")
-else()
-	message("-- H5CPP ${PROJECT_VERSION} matches with minimum required HDF5 v${HDF5_VERSION}")
-endif()
-
-if(HDF5_VERSION VERSION_GREATER 1.12.0)
-	message("H5CPP KITA support is available, see webpage for details...")
-endif()
-
-include(FindMPI MPI_SKIP_COMPILER_WRAPPER)
-if( MPI_FOUND AND HDF5_IS_PARALLEL )
-	message("-- MPI and PHDF5 found: Parallel H5CPP enabled")
-endif()
-
-
-find_package(GTest)
-find_package(fmt)
-
-option(H5CPP_BUILD_TESTS "Build tests" OFF)
-if(H5CPP_BUILD_TESTS)
-	message("-- gtest is disabled in the version, new test framework in progress...")
-endif()
-
-
-#installation
-target_include_directories(h5cpp INTERFACE
-	$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+# match hdf5 versioning x.x.x.h5cpp-version
+set(H5CPP_VERSION
+    ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}
 )
 
 if(WIN32)
-	if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-		set (CMAKE_INSTALL_PREFIX "C:/linalg" CACHE PATH "default install path" FORCE )
-	endif()
-	set(INSTALL_DIR_CMAKE "${CMAKE_INSTALL_PREFIX}/share/h5cpp/cmake")
-	set(INSTALL_DIR_INCLUDE  "${CMAKE_INSTALL_PREFIX}/include")
-	set(INSTALL_DIR_EXAMPLES "${CMAKE_INSTALL_PREFIX}/examples")
+    if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+        set(CMAKE_INSTALL_PREFIX "C:/h5cpp" CACHE PATH "default install path" FORCE)
+    endif()
 elseif(UNIX)
-	set(INSTALL_DIR_CMAKE    "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/cmake/h5cpp")
-	set(INSTALL_DIR_INCLUDE  "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}")
-	set(INSTALL_DIR_EXAMPLES "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATADIR}/h5cpp")
+    # Prefer system locations where distro HDF5 packages are commonly installed
+    set(HDF5_ROOT "/usr/local" "/usr")
+    find_package(PkgConfig REQUIRED QUIET)
 endif()
 
-message( "-- Install directory: ${INSTALL_DIR_INCLUDE}")
+if(APPLE)
+    message(STATUS "***WARNING: h5cpp is not fully tested on apple ***")
+endif()
 
-# copy header only library into DESTDIR
+if(ANDROID)
+    message(STATUS "***WARNING: h5cpp is not fully tested on android ***")
+endif()
+
+# HDF5
+find_package(HDF5 REQUIRED COMPONENTS C HL)
+
+if(HDF5_VERSION VERSION_LESS ${H5CPP_VERSION})
+    message(FATAL_ERROR
+        "-- !!! H5CPP examples require HDF5 v${H5CPP_VERSION} or greater !!!"
+    )
+else()
+    message(STATUS
+        "H5CPP ${PROJECT_VERSION} matches with minimum required HDF5 v${HDF5_VERSION}"
+    )
+endif()
+
+if(HDF5_VERSION VERSION_GREATER 1.12.0)
+    message(STATUS "H5CPP KITA support is available, see webpage for details...")
+endif()
+
+# MPI is optional
+find_package(MPI QUIET COMPONENTS C CXX)
+if(MPI_FOUND AND HDF5_IS_PARALLEL)
+    message(STATUS "MPI and PHDF5 found: Parallel H5CPP enabled")
+endif()
+
+option(H5CPP_BUILD_TESTS "Build tests" OFF)
+
+# Header-only target
+add_library(h5cpp INTERFACE)
+add_library(h5cpp::h5cpp ALIAS h5cpp)
+
+target_include_directories(h5cpp INTERFACE
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${HDF5_INCLUDE_DIRS}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
+target_link_libraries(h5cpp INTERFACE
+    Threads::Threads
+    ${HDF5_LIBRARIES}
+)
+
+target_compile_features(h5cpp INTERFACE cxx_std_17)
+
+if(WIN32)
+    set(INSTALL_DIR_CMAKE    "${CMAKE_INSTALL_PREFIX}/share/h5cpp/cmake")
+    set(INSTALL_DIR_INCLUDE  "${CMAKE_INSTALL_PREFIX}/include")
+    set(INSTALL_DIR_EXAMPLES "${CMAKE_INSTALL_PREFIX}/examples")
+elseif(UNIX)
+    set(INSTALL_DIR_CMAKE    "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/cmake/h5cpp")
+    set(INSTALL_DIR_INCLUDE  "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}")
+    set(INSTALL_DIR_EXAMPLES "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DATADIR}/h5cpp")
+endif()
+
+message(STATUS "Install directory: ${INSTALL_DIR_INCLUDE}")
+
+# Install header-only library
 install(DIRECTORY h5cpp DESTINATION ${INSTALL_DIR_INCLUDE})
 install(TARGETS h5cpp EXPORT h5cpp-targets)
 
-install(DIRECTORY examples/attributes     DESTINATION "${INSTALL_DIR_EXAMPLES}")
-install(DIRECTORY examples/basics         DESTINATION "${INSTALL_DIR_EXAMPLES}")
-install(DIRECTORY examples/compound       DESTINATION "${INSTALL_DIR_EXAMPLES}")
-install(DIRECTORY examples/csv       	  DESTINATION "${INSTALL_DIR_EXAMPLES}")
-install(DIRECTORY examples/datasets    	  DESTINATION "${INSTALL_DIR_EXAMPLES}")
-install(DIRECTORY examples/datatypes   	  DESTINATION "${INSTALL_DIR_EXAMPLES}")
-install(DIRECTORY examples/half-float  	  DESTINATION "${INSTALL_DIR_EXAMPLES}")
-install(DIRECTORY examples/linalg         DESTINATION "${INSTALL_DIR_EXAMPLES}")
-install(DIRECTORY examples/multi-tu       DESTINATION "${INSTALL_DIR_EXAMPLES}")
-install(DIRECTORY examples/optimized      DESTINATION "${INSTALL_DIR_EXAMPLES}")
-install(DIRECTORY examples/packet-table   DESTINATION "${INSTALL_DIR_EXAMPLES}")
-install(DIRECTORY examples/raw_memory     DESTINATION "${INSTALL_DIR_EXAMPLES}")
-install(DIRECTORY examples/stl            DESTINATION "${INSTALL_DIR_EXAMPLES}")
-install(DIRECTORY examples/string         DESTINATION "${INSTALL_DIR_EXAMPLES}")
-install(DIRECTORY examples/transform      DESTINATION "${INSTALL_DIR_EXAMPLES}")
-install(DIRECTORY examples/utf            DESTINATION "${INSTALL_DIR_EXAMPLES}")
+# Install examples
+install(DIRECTORY examples/attributes   DESTINATION "${INSTALL_DIR_EXAMPLES}")
+install(DIRECTORY examples/basics       DESTINATION "${INSTALL_DIR_EXAMPLES}")
+install(DIRECTORY examples/compound     DESTINATION "${INSTALL_DIR_EXAMPLES}")
+install(DIRECTORY examples/csv          DESTINATION "${INSTALL_DIR_EXAMPLES}")
+install(DIRECTORY examples/datasets     DESTINATION "${INSTALL_DIR_EXAMPLES}")
+install(DIRECTORY examples/datatypes    DESTINATION "${INSTALL_DIR_EXAMPLES}")
+install(DIRECTORY examples/half-float   DESTINATION "${INSTALL_DIR_EXAMPLES}")
+install(DIRECTORY examples/multi-tu     DESTINATION "${INSTALL_DIR_EXAMPLES}")
+install(DIRECTORY examples/optimized    DESTINATION "${INSTALL_DIR_EXAMPLES}")
+install(DIRECTORY examples/packet-table DESTINATION "${INSTALL_DIR_EXAMPLES}")
+install(DIRECTORY examples/raw_memory   DESTINATION "${INSTALL_DIR_EXAMPLES}")
+install(DIRECTORY examples/stl          DESTINATION "${INSTALL_DIR_EXAMPLES}")
+install(DIRECTORY examples/string       DESTINATION "${INSTALL_DIR_EXAMPLES}")
+install(DIRECTORY examples/transform    DESTINATION "${INSTALL_DIR_EXAMPLES}")
+install(DIRECTORY examples/utf          DESTINATION "${INSTALL_DIR_EXAMPLES}")
 install(FILES     examples/CMakeLists.txt DESTINATION "${INSTALL_DIR_EXAMPLES}")
 install(FILES     examples/Makefile       DESTINATION "${INSTALL_DIR_EXAMPLES}")
 
-#generate cmake config and version files
+# Package config
 include(CMakePackageConfigHelpers)
+
 configure_package_config_file(
     ${CMAKE_SOURCE_DIR}/cmake/config.cmake.in
     ${CMAKE_BINARY_DIR}/h5cpp-config.cmake
     INSTALL_DESTINATION ${INSTALL_DIR_CMAKE}
 )
+
 write_basic_package_version_file(
     ${CMAKE_BINARY_DIR}/h5cpp-config-version.cmake
     VERSION ${PROJECT_VERSION}
@@ -125,3 +150,11 @@ install(FILES
     DESTINATION ${INSTALL_DIR_CMAKE}
 )
 
+
+if(H5CPP_BUILD_EXAMPLES)
+    add_subdirectory(examples)
+endif()
+
+if(H5CPP_BUILD_TESTS AND EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/test/CMakeLists.txt)
+    add_subdirectory(test)
+endif()


### PR DESCRIPTION
Refs #82.

Modernizes the root `CMakeLists.txt` for C++17 and clean package exports:

- Enforce C++17 (`CMAKE_CXX_STANDARD 17`, `REQUIRED`, `EXTENSIONS OFF`)
- Add `GNUInstallDirs` and standardize install paths
- Replace `include(FindHDF5)` with `find_package(HDF5 REQUIRED COMPONENTS C HL)`
- Add `H5CPP_BUILD_EXAMPLES` and `H5CPP_BUILD_TESTS` options (both `OFF` by default)
- Enable `CMAKE_EXPORT_COMPILE_COMMANDS` for tooling (clangd, VS Code)
- Update copyright/license header to SPDX form

No production headers modified. No test files included.

This branch is the base for `issue/95-doctest`.