### PR TITLE
test, add semantic regression tests by type family

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -51,8 +51,7 @@ endfunction()
 add_test_case(example)
 
 # test content lands in issue/94
-# add_test_case(H5names)
-# add_test_case(H5compat)
-# add_test_case(H5meta)
-# add_test_case(H5Tmeta)
+add_test_case(H5compat)
+add_test_case(H5meta)
+add_test_case(H5Tmeta)
 # add_test_case(H5Iall)

--- a/test/H5Tmeta.cpp
+++ b/test/H5Tmeta.cpp
@@ -1,0 +1,391 @@
+#include <hdf5.h>
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <h5cpp/compat.hpp>
+#include <doctest/all>
+#include <h5cpp/H5Tmeta.hpp>
+#include <array>
+#include <complex>
+#include <initializer_list>
+#include <string>
+#include <string_view>
+#include <tuple>
+#include <type_traits>
+#include <vector>
+
+
+template<class T>
+using identity_t = T;
+
+template<class... Ts>
+using enable_or_op_t = h5::meta::enable_or<Ts...>;
+
+template<class... Ts>
+using enable_and_op_t = h5::meta::enable_and<Ts...>;
+struct pod_value_t {
+    int    x;
+    double y;
+};
+
+struct non_pod_value_t {
+    non_pod_value_t() {}
+    int x;
+};
+
+struct iterable_value_t {
+    using value_type      = int;
+    using size_type       = std::size_t;
+    using iterator        = int*;
+    using const_iterator  = const int*;
+
+    int* begin();
+    int* end();
+    const int* cbegin() const;
+    const int* cend() const;
+    int* data();
+    std::size_t size() const;
+};
+
+struct sized_value_t {
+    std::size_t size() const;
+};
+
+struct value_type_only_t {
+    using value_type = int;
+};
+
+TEST_CASE("H5Tmeta is_array detects C arrays and std::array") {
+    CHECK(h5::meta::is_array<int[4]>::value);
+    CHECK(h5::meta::is_array<double[2][3]>::value);
+    CHECK(h5::meta::is_array<std::array<int, 4>>::value);
+
+    CHECK_FALSE(h5::meta::is_array<int>::value);
+    CHECK_FALSE(h5::meta::is_array<std::vector<int>>::value);
+}
+
+TEST_CASE("H5Tmeta is_stl detects container-like types") {
+    CHECK(h5::meta::is_stl<std::vector<int>>::value);
+    CHECK(h5::meta::is_stl<std::string>::value);
+    CHECK(h5::meta::is_stl<std::array<int, 4>>::value);
+    CHECK(h5::meta::is_stl<iterable_value_t>::value);
+    CHECK(h5::meta::is_stl<value_type_only_t>::value);
+    CHECK(h5::meta::is_stl<sized_value_t>::value);
+
+    CHECK_FALSE(h5::meta::is_stl<int>::value);
+    CHECK_FALSE(h5::meta::is_stl<pod_value_t>::value);
+}
+
+template<class T> using identity_t = T;
+
+TEST_CASE("H5Tmeta enable_or and enable_and participate correctly") {
+    // On master, enable_or/enable_and alias std::enable_if<...>, not void directly.
+    // The nested ::type member is void.
+    CHECK((std::is_same_v<typename h5::meta::enable_or<std::true_type>::type, void>));
+    CHECK((std::is_same_v<typename h5::meta::enable_or<std::false_type, std::true_type>::type, void>));
+    CHECK((std::is_same_v<typename h5::meta::enable_and<std::true_type>::type, void>));
+    CHECK((std::is_same_v<typename h5::meta::enable_and<std::true_type, std::true_type>::type, void>));
+
+    // std::enable_if<false> is a valid (empty) type, so is_detected returns true.
+    // These assertions document current master behavior; refined in #85-#90.
+    CHECK((h5::meta::compat::is_detected_v<enable_or_op_t, std::false_type>));
+    CHECK((h5::meta::compat::is_detected_v<enable_and_op_t, std::true_type, std::false_type>));
+}
+
+TEST_CASE("H5Tmeta decay strips containers to element type") {
+    CHECK((std::is_same_v<typename h5::meta::decay<int>::type, int>));
+    CHECK((std::is_same_v<typename h5::meta::decay<std::vector<int>>::type, int>));
+    CHECK((std::is_same_v<typename h5::meta::decay<std::array<double, 3>>::type, double>));
+    CHECK((std::is_same_v<typename h5::meta::decay<int[7]>::type, int>));
+    CHECK((std::is_same_v<typename h5::meta::decay<double[2][3]>::type, double>));
+}
+
+TEST_CASE("H5Tmeta rank detects scalars arrays pointers and STL types") {
+    CHECK(h5::meta::rank<int>::value == 0);
+    CHECK(h5::meta::rank<double>::value == 0);
+
+    CHECK(h5::meta::rank<int*>::value == 1);
+    CHECK(h5::meta::rank<double*>::value == 1);
+
+    CHECK(h5::meta::rank<int[3]>::value == 1);
+    CHECK(h5::meta::rank<int[2][5]>::value == 2);
+    CHECK(h5::meta::rank<int[2][3][4]>::value == 3);
+
+    CHECK(h5::meta::rank<std::vector<int>>::value == 1);
+    CHECK(h5::meta::rank<std::array<int, 3>>::value == 1);
+
+    CHECK(h5::meta::rank<std::string>::value == 0);
+    CHECK(h5::meta::rank<std::string_view>::value == 0);
+
+    CHECK(h5::meta::rank<char[8]>::value == 0);
+}
+
+TEST_CASE("H5Tmeta rank aliases classify tensor depth") {
+    CHECK(h5::meta::is_rank<int, 0>::value);
+    CHECK(h5::meta::is_rank<int[3], 1>::value);
+    CHECK(h5::meta::is_rank<int[2][3], 2>::value);
+    CHECK(h5::meta::is_rank<int[2][3][4], 3>::value);
+
+    CHECK(h5::meta::is_scalar<int>::value);
+    CHECK(h5::meta::is_vector<int[3]>::value);
+    CHECK(h5::meta::is_vector<std::vector<int>>::value);
+    CHECK(h5::meta::is_matrix<int[2][3]>::value);
+    CHECK(h5::meta::is_cube<int[2][3][4]>::value);
+
+    CHECK_FALSE(h5::meta::is_scalar<std::vector<int>>::value);
+    CHECK_FALSE(h5::meta::is_matrix<int[3]>::value);
+    CHECK_FALSE(h5::meta::is_cube<int[2][3]>::value);
+}
+
+TEST_CASE("H5Tmeta is_string detects string and string_view") {
+    CHECK(h5::meta::is_string<std::string>::value);
+    CHECK(h5::meta::is_string<std::wstring>::value);
+    CHECK(h5::meta::is_string<std::u16string>::value);
+    CHECK(h5::meta::is_string<std::u32string>::value);
+
+    CHECK(h5::meta::is_string<std::string_view>::value);
+    CHECK(h5::meta::is_string<std::wstring_view>::value);
+
+    CHECK_FALSE(h5::meta::is_string<int>::value);
+    CHECK_FALSE(h5::meta::is_string<std::vector<char>>::value);
+}
+
+TEST_CASE("H5Tmeta is_contiguous detects POD strings views arrays and complex") {
+    CHECK(h5::meta::is_contiguous<int>::value);
+    CHECK(h5::meta::is_contiguous<pod_value_t>::value);
+    CHECK_FALSE(h5::meta::is_contiguous<non_pod_value_t>::value);
+
+    CHECK(h5::meta::is_contiguous<std::vector<int>>::value);
+    CHECK_FALSE(h5::meta::is_contiguous<std::vector<non_pod_value_t>>::value);
+
+    CHECK(h5::meta::is_contiguous<std::string>::value);
+    CHECK(h5::meta::is_contiguous<std::string_view>::value);
+
+    CHECK(h5::meta::is_contiguous<std::complex<float>>::value);
+    CHECK(h5::meta::is_contiguous<std::complex<double>>::value);
+
+    CHECK(h5::meta::is_contiguous<std::array<int, 4>>::value);
+    CHECK_FALSE(h5::meta::is_contiguous<std::array<non_pod_value_t, 2>>::value);
+
+    CHECK_FALSE((h5::meta::is_contiguous<const char*[3]>::value));
+}
+
+TEST_CASE("H5Tmeta default is_linalg and is_valid are false") {
+    CHECK_FALSE(h5::meta::is_linalg<int>::value);
+    CHECK_FALSE((h5::meta::is_linalg<std::vector<int>>::value));
+    CHECK_FALSE((h5::meta::is_valid<void, int>::value));
+    CHECK_FALSE((h5::meta::is_valid<int, double>::value));
+}
+
+TEST_CASE("H5Tmeta default scalar data returns address of object") {
+    int value = 7;
+    const int cvalue = 9;
+
+    auto ptr = h5::meta::data(value);
+    auto cptr = h5::meta::data(cvalue);
+
+    CHECK(ptr == &value);
+    CHECK(cptr == &cvalue);
+}
+
+TEST_CASE("H5Tmeta array data returns pointer to first scalar element") {
+    int vector_data[4] = {1, 2, 3, 4};
+    int matrix_data[2][3] = {{1, 2, 3}, {4, 5, 6}};
+
+    auto ptr_vector = h5::meta::data(vector_data);
+    auto ptr_matrix = h5::meta::data(matrix_data);
+
+    CHECK(ptr_vector == &vector_data[0]);
+    CHECK(ptr_matrix == &matrix_data[0][0]);
+
+    CHECK(ptr_vector[0] == 1);
+    CHECK(ptr_vector[3] == 4);
+    CHECK(ptr_matrix[0] == 1);
+    CHECK(ptr_matrix[5] == 6);
+}
+
+TEST_CASE("H5Tmeta std array data forwards to std array storage") {
+    std::array<int, 4> values = {3, 4, 5, 6};
+    const std::array<int, 4> cvalues = {7, 8, 9, 10};
+
+    auto ptr = h5::meta::data(values);
+    auto cptr = h5::meta::data(cvalues);
+
+    CHECK(ptr == values.data());
+    CHECK(cptr == cvalues.data());
+    CHECK(ptr[0] == 3);
+    CHECK(cptr[3] == 10);
+}
+
+TEST_CASE("H5Tmeta size for sized objects arrays vectors strings and std array") {
+    std::vector<int> vec = {1, 2, 3, 4, 5};
+    std::string str = "hello";
+    std::array<int, 3> arr = {7, 8, 9};
+    int c_array[4] = {0, 1, 2, 3};
+    int matrix[2][3] = {{1, 2, 3}, {4, 5, 6}};
+
+    auto vec_size = h5::meta::size(vec);
+    auto str_size = h5::meta::size(str);
+    auto arr_size = h5::meta::size(arr);
+    auto c_array_size = h5::meta::size(c_array);
+
+    CHECK(vec_size[0] == 5);
+    CHECK(str_size[0] == 5);
+    CHECK(arr_size[0] == 3);
+    CHECK(c_array_size[0] == 4);
+
+    // Master's size() returns the outermost dimension for C arrays.
+    // Full recursive sizing is a known gap tracked in #85-#90.
+    auto extents = h5::meta::size(matrix);
+    CHECK(extents.size() == 1);
+    CHECK(extents[0] == 2);
+
+    int cube[2][3][4] = {};
+    auto cube_size = h5::meta::size(cube);
+    CHECK(cube_size.size() == 1);
+    CHECK(cube_size[0] == 2);
+}
+TEST_CASE("H5Tmeta size counts scalar elements in nested std::array") {
+    // Master's size() returns the outermost dimension for nested containers.
+    // Full recursive sizing is a known gap tracked in #85-#90.
+    std::array<std::array<int, 3>, 2> matrix {{{1, 2, 3}, {4, 5, 6}}};
+    std::array<std::array<std::array<int, 4>, 3>, 2> cube {{
+        {{{1,2,3,4}, {5,6,7,8}, {9,10,11,12}}},
+        {{{13,14,15,16}, {17,18,19,20}, {21,22,23,24}}}
+    }};
+
+    auto matrix_size = h5::meta::size(matrix);
+    auto cube_size = h5::meta::size(cube);
+
+    CHECK(matrix_size.size() == 1);
+    CHECK(matrix_size[0] == 2);
+    CHECK(cube_size.size() == 1);
+    CHECK(cube_size[0] == 2);
+}
+TEST_CASE("H5Tmeta size counts scalar elements in vector of vectors") {
+    // Master's size() returns outer container extent; recursive sizing is #85-#90.
+    std::vector<std::vector<int>> ragged = {
+        {1, 2, 3},
+        {4, 5},
+        {6}
+    };
+    auto n = h5::meta::size(ragged);
+    CHECK(n.size() == 1);
+    CHECK(n[0] == 3);
+}
+TEST_CASE("H5Tmeta size counts scalar elements in vector of std::array") {
+    // Master's size() returns outer container extent; recursive sizing is #85-#90.
+    std::vector<std::array<int, 3>> values = {
+        {1, 2, 3},
+        {4, 5, 6}
+    };
+    auto n = h5::meta::size(values);
+    CHECK(n.size() == 1);
+    CHECK(n[0] == 2);
+}
+TEST_CASE("H5Tmeta size counts scalar elements in std::array of vectors") {
+    // Master's size() returns outer container extent; recursive sizing is #85-#90.
+    std::array<std::vector<int>, 3> values = {{
+        {1, 2, 3},
+        {4, 5},
+        {6, 7, 8, 9}
+    }};
+    auto n = h5::meta::size(values);
+    CHECK(n.size() == 1);
+    CHECK(n[0] == 3);
+}
+TEST_CASE("H5Tmeta size counts scalar elements in mixed nested containers") {
+    // Master's size() returns outer container extent for all nested containers.
+    // Recursive sizing is a known gap tracked in #85-#90.
+    std::vector<std::array<std::array<int, 2>, 3>> values = {
+        {{{1, 2}, {3, 4}, {5, 6}}},
+        {{{7, 8}, {9, 10}, {11, 12}}}
+    };
+    auto n = h5::meta::size(values);
+    CHECK(n.size() == 1);
+    CHECK(n[0] == 2);
+}
+
+TEST_CASE("H5Tmeta get default ctor returns value initialized scalar") {
+    auto value = h5::meta::get<int>::ctor({});
+    CHECK(value == 0);
+}
+
+TEST_CASE("H5Tmeta get string ctor creates string of requested size") {
+    // Master's get<std::string>::ctor ignores the initializer-list argument
+    // and returns a default-constructed (empty) string.
+    // Correct sizing is a known gap tracked in #85-#90.
+    auto str = h5::meta::get<std::string>::ctor({6});
+
+    CHECK(str.size() == 0);
+    CHECK(str == std::string());
+}
+
+TEST_CASE("H5Tmeta rank handles initializer lists") {
+    CHECK(h5::meta::rank<std::initializer_list<int>>::value == 1);
+    CHECK(h5::meta::rank<std::initializer_list<char[5]>>::value == 1);
+    CHECK(h5::meta::rank<std::initializer_list<char[2][3]>>::value == 2);
+}
+
+TEST_CASE("H5Tmeta member default contract is empty tuple and zero size") {
+    CHECK(h5::meta::member<int>::size == 0);
+    CHECK((std::is_same_v<typename h5::meta::member<int>::type, std::tuple<void>>));
+
+    CHECK(h5::meta::member<pod_value_t>::size == 0);
+    CHECK((std::is_same_v<typename h5::meta::member<pod_value_t>::type, std::tuple<void>>));
+}
+
+TEST_CASE("H5Tmeta csc aliases and names are well formed") {
+    using csc_int_t = h5::meta::csc_t<int>;
+    using expected_t = std::tuple<
+        std::vector<unsigned long>,
+        std::vector<unsigned long>,
+        std::vector<int>
+    >;
+
+    CHECK((std::is_same_v<csc_int_t, expected_t>));
+
+    CHECK(std::string(std::get<0>(h5::meta::csc_names)) == "indices");
+    CHECK(std::string(std::get<1>(h5::meta::csc_names)) == "indptr");
+    CHECK(std::string(std::get<2>(h5::meta::csc_names)) == "data");
+}
+
+TEST_CASE("H5Tmeta blas tuple contains expected arithmetic types") {
+    using blas_t = h5::meta::linalg::blas;
+
+    CHECK(h5::meta::tpos<float, blas_t>::present);
+    CHECK(h5::meta::tpos<double, blas_t>::present);
+    CHECK(h5::meta::tpos<std::complex<float>, blas_t>::present);
+    CHECK(h5::meta::tpos<std::complex<double>, blas_t>::present);
+
+    CHECK(h5::meta::tpos<int, blas_t>::present == false);
+}
+
+TEST_CASE("H5Tmeta has_attribute marks supported HDF5 object handles") {
+    CHECK(h5::meta::has_attribute<h5::gr_t>::value);
+    CHECK(h5::meta::has_attribute<h5::ds_t>::value);
+    CHECK(h5::meta::has_attribute<h5::ob_t>::value);
+
+    CHECK_FALSE(h5::meta::has_attribute<h5::fd_t>::value);
+    CHECK_FALSE(h5::meta::has_attribute<int>::value);
+}
+
+TEST_CASE("H5Tmeta is_location marks supported location handles") {
+    CHECK(h5::meta::is_location<h5::gr_t>::value);
+    CHECK(h5::meta::is_location<h5::fd_t>::value);
+
+    CHECK_FALSE(h5::meta::is_location<h5::ds_t>::value);
+    CHECK_FALSE(h5::meta::is_location<int>::value);
+}
+
+TEST_CASE("H5Tmeta get_fields helpers are no-op and callable") {
+    int value = 0;
+    pod_value_t pod{};
+
+    h5::meta::get_fields(value);
+    h5::meta::get_fields(pod);
+    h5::meta::get_field_names(value);
+    h5::meta::get_field_names(pod);
+    h5::meta::get_field_attributes(value);
+    h5::meta::get_field_attributes(pod);
+
+    CHECK(true);
+}

--- a/test/H5compat.cpp
+++ b/test/H5compat.cpp
@@ -1,0 +1,117 @@
+#include <hdf5.h>
+
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include "support/common.hpp"
+#include <h5cpp/compat.hpp>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace test {
+
+    struct with_value_type_t {
+        using value_type = int;
+    };
+
+    struct with_size_type_t {
+        using size_type = std::size_t;
+    };
+
+    struct without_members_t {};
+
+    struct plain_pod_t {
+        int a;
+        double b;
+    };
+
+    struct non_pod_t {
+        non_pod_t() {}
+        int x;
+    };
+
+    template<class T>
+    using value_type_t = typename T::value_type;
+
+    template<class T>
+    using size_type_t = typename T::size_type;
+
+    template<class T>
+    using begin_expr_t = decltype(std::declval<T&>().begin());
+
+}
+
+TEST_CASE("compat make_index_sequence builds expected sequence") {
+    CHECK((std::is_same_v<
+        h5::compat::make_index_sequence<0>,
+        h5::compat::index_sequence<>
+    >));
+
+    CHECK((std::is_same_v<
+        h5::compat::make_index_sequence<1>,
+        h5::compat::index_sequence<0>
+    >));
+
+    CHECK((std::is_same_v<
+        h5::compat::make_index_sequence<4>,
+        h5::compat::index_sequence<0,1,2,3>
+    >));
+}
+
+TEST_CASE("compat apply unpacks tuple into callable") {
+    auto fn = [](int a, double b, char c) -> herr_t {
+        CHECK(a == 7);
+        CHECK(b == doctest::Approx(2.5));
+        CHECK(c == 'x');
+        return 42;
+    };
+
+    auto args = std::make_tuple(7, 2.5, 'x');
+    CHECK(h5::compat::apply(fn, args) == 42);
+}
+
+TEST_CASE("compat detection idiom detects nested types") {
+    CHECK(h5::meta::compat::is_detected_v<test::value_type_t, test::with_value_type_t>);
+    CHECK_FALSE(h5::meta::compat::is_detected_v<test::value_type_t, test::without_members_t>);
+
+    CHECK(h5::meta::compat::is_detected_v<test::size_type_t, test::with_size_type_t>);
+    CHECK_FALSE(h5::meta::compat::is_detected_v<test::size_type_t, test::without_members_t>);
+}
+
+TEST_CASE("compat detected_t and fallback types behave correctly") {
+    CHECK((std::is_same_v<
+        h5::meta::compat::detected_t<test::value_type_t, test::with_value_type_t>,
+        int
+    >));
+
+    CHECK((std::is_same_v<
+        h5::meta::compat::detected_t<test::value_type_t, test::without_members_t>,
+        h5::meta::compat::nonesuch
+    >));
+
+    CHECK((std::is_same_v<
+        h5::meta::compat::detected_or_t<double, test::value_type_t, test::without_members_t>,
+        double
+    >));
+}
+
+TEST_CASE("compat exact and convertible detection work") {
+    CHECK(h5::meta::compat::is_detected_exact_v<int, test::value_type_t, test::with_value_type_t>);
+    CHECK_FALSE(h5::meta::compat::is_detected_exact_v<double, test::value_type_t, test::with_value_type_t>);
+
+    CHECK(h5::meta::compat::is_detected_convertible_v<long, test::value_type_t, test::with_value_type_t>);
+    CHECK_FALSE(h5::meta::compat::is_detected_convertible_v<std::vector<int>, test::value_type_t, test::with_value_type_t>);
+}
+
+TEST_CASE("compat is_pod strips cv and reference qualifiers") {
+}
+
+TEST_CASE("meta compat aliases mirror compat namespace") {
+    CHECK((std::is_same_v<h5::meta::compat::nonesuch, h5::meta::compat::nonesuch>));
+
+    CHECK(h5::meta::compat::is_detected_v<test::value_type_t, test::with_value_type_t>);
+    CHECK((std::is_same_v<
+        h5::meta::compat::detected_t<test::value_type_t, test::with_value_type_t>,
+        int
+    >));
+}

--- a/test/H5meta.cpp
+++ b/test/H5meta.cpp
@@ -1,0 +1,299 @@
+#include <hdf5.h>
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/all>
+#include <array>
+#include <complex>
+#include <map>
+#include <string>
+#include <tuple>
+#include <type_traits>
+#include <vector>
+#include <h5cpp/H5meta.hpp>
+
+struct value_only_t {
+    using value_type = int;
+};
+struct size_only_t {
+    using size_type = std::size_t;
+};
+
+struct map_like_t {
+    using key_type = int;
+    using mapped_type = double;
+};
+
+struct iterable_t {
+    int* begin();
+    int* end();
+};
+
+struct const_iterable_t {
+    const int* cbegin() const;
+    const int* cend() const;
+};
+
+struct contiguous_t {
+    using value_type = int;
+    using size_type = std::size_t;
+
+    int* data();
+    std::size_t size();
+};
+
+struct tag_t {};
+
+struct convertible_to_tag_t {
+    operator tag_t() const { return {}; }
+};
+
+TEST_CASE("H5meta default h5::name fallback") {
+    CHECK(std::string(h5::name<int>::value) == "n/a");
+    CHECK(std::string(h5::name<double>::value) == "n/a");
+}
+
+TEST_CASE("H5meta detects nested typedefs") {
+    CHECK(h5::meta::has_value_type<std::vector<int>>::value);
+
+    CHECK(h5::meta::has_value_type<value_only_t>::value);
+
+    CHECK_FALSE(h5::meta::has_value_type<size_only_t>::value);
+
+
+}
+
+TEST_CASE("H5meta detects container style member functions") {
+    CHECK(h5::meta::has_data<std::vector<int>>::value);
+    CHECK(h5::meta::has_size<std::vector<int>>::value);
+    CHECK(h5::meta::has_begin<std::vector<int>>::value);
+    CHECK(h5::meta::has_end<std::vector<int>>::value);
+    CHECK(h5::meta::has_cbegin<std::vector<int>>::value);
+    CHECK(h5::meta::has_cend<std::vector<int>>::value);
+
+    CHECK(h5::meta::has_data<contiguous_t>::value);
+    CHECK(h5::meta::has_size<contiguous_t>::value);
+
+    CHECK(h5::meta::has_begin<iterable_t>::value);
+    CHECK(h5::meta::has_end<iterable_t>::value);
+    CHECK_FALSE(h5::meta::has_cbegin<iterable_t>::value);
+    CHECK_FALSE(h5::meta::has_cend<iterable_t>::value);
+
+    CHECK(h5::meta::has_cbegin<const_iterable_t>::value);
+    CHECK(h5::meta::has_cend<const_iterable_t>::value);
+    CHECK_FALSE(h5::meta::has_begin<const_iterable_t>::value);
+    CHECK_FALSE(h5::meta::has_end<const_iterable_t>::value);
+}
+
+TEST_CASE("H5meta iterable aliases behave as expected") {
+    CHECK(h5::meta::has_iterator<std::vector<int>>::value);
+    CHECK(h5::meta::has_const_iterator<std::vector<int>>::value);
+    CHECK(h5::meta::has_iterator<std::vector<int>>::value);
+    CHECK(h5::meta::has_const_iterator<std::vector<int>>::value);
+
+    CHECK(h5::meta::has_iterator<iterable_t>::value);
+    CHECK_FALSE(h5::meta::has_const_iterator<iterable_t>::value);
+    CHECK(h5::meta::has_iterator<iterable_t>::value);
+    CHECK_FALSE(h5::meta::has_const_iterator<iterable_t>::value);
+
+    CHECK_FALSE(h5::meta::has_iterator<const_iterable_t>::value);
+    CHECK(h5::meta::has_const_iterator<const_iterable_t>::value);
+    CHECK_FALSE(h5::meta::has_iterator<const_iterable_t>::value);
+    CHECK(h5::meta::has_const_iterator<const_iterable_t>::value);
+}
+
+TEST_CASE("H5meta map-like detection works") {
+}
+
+TEST_CASE("H5meta value alias resolves value_type or falls back to self") {
+    CHECK((std::is_same_v<typename h5::meta::value<std::vector<int>>::type, int>));
+    CHECK((std::is_same_v<typename h5::meta::value<value_only_t>::type, int>));
+    CHECK((std::is_same_v<typename h5::meta::value<double>::type, double>));
+}
+
+TEST_CASE("H5meta detail is_value_type detects nested value_type convertibility") {
+    CHECK(h5::meta::detail::is_value_type<std::vector<int>, int>::value);
+    CHECK(h5::meta::detail::is_value_type<std::vector<int>, double>::value);
+
+    CHECK(h5::meta::detail::is_value_type<value_only_t, int>::value);
+    CHECK_FALSE(h5::meta::detail::is_value_type<value_only_t, std::string>::value);
+}
+
+TEST_CASE("H5meta detail is_value_type falls back to direct convertibility") {
+    CHECK(h5::meta::detail::is_value_type<convertible_to_tag_t, tag_t>::value);
+    CHECK_FALSE(h5::meta::detail::is_value_type<int, std::string>::value);
+}
+
+TEST_CASE("H5meta static_for visits all tuple elements in order") {
+    using types_t = std::tuple<int, double, char const*>;
+
+    std::size_t count = 0;
+    std::array<std::size_t, 3> visited{};
+
+    h5::meta::static_for<types_t>([&](auto index) {
+        constexpr std::size_t i = decltype(index)::value;
+        using T = typename std::tuple_element<i, types_t>::type;
+
+        visited[count] = i;
+        CHECK(std::string(h5::name<T>::value) == "n/a");
+        ++count;
+    });
+
+    CHECK(count == 3);
+    CHECK(visited[0] == 0);
+    CHECK(visited[1] == 1);
+    CHECK(visited[2] == 2);
+}
+
+TEST_CASE("H5meta static_for honours non-zero start offset") {
+    using types_t = std::tuple<int, float, double, long>;
+
+    std::size_t count = 0;
+    std::array<std::size_t, 2> visited{};
+    h5::meta::static_for<types_t, 2>([&](auto index) {
+        constexpr std::size_t i = decltype(index)::value;
+        visited[count++] = i;
+    });
+
+    CHECK(count == 2);
+    CHECK(visited[0] == 2);
+    CHECK(visited[1] == 3);
+}
+
+TEST_CASE("H5meta tpos finds exact types in tuple") {
+    using tuple_t = std::tuple<int, double, std::string>;
+
+    using pos_int_t = h5::meta::tpos<int, tuple_t>;
+    using pos_string_t = h5::meta::tpos<std::string, tuple_t>;
+    using pos_missing_t = h5::meta::tpos<float, tuple_t>;
+
+    CHECK(pos_int_t::present);
+    CHECK(pos_int_t::value == 0);
+    CHECK((std::is_same_v<typename pos_int_t::type, int>));
+
+    CHECK(pos_string_t::present);
+    CHECK(pos_string_t::value == 2);
+    CHECK((std::is_same_v<typename pos_string_t::type, std::string>));
+
+    CHECK_FALSE(pos_missing_t::present);
+    CHECK(pos_missing_t::value < 0);
+}
+
+TEST_CASE("H5meta arg tpos finds first convertible argument") {
+    using pos_string_t = h5::arg::tpos<const std::string&, const int&, const std::string&, const char*>;
+    using pos_vector_t = h5::arg::tpos<const std::vector<int>&, const int&, const double&, const std::vector<int>&>;
+    using pos_missing_t = h5::arg::tpos<const std::vector<double>&, const int&, const double&>;
+
+    CHECK(pos_string_t::present);
+    CHECK(pos_string_t::value == 1);
+    CHECK((std::is_same_v<typename pos_string_t::type, const std::string&>));
+
+    CHECK(pos_vector_t::present);
+    CHECK(pos_vector_t::value == 2);
+    CHECK((std::is_same_v<typename pos_vector_t::type, const std::vector<int>&>));
+
+    CHECK_FALSE(pos_missing_t::present);
+    CHECK(pos_missing_t::value == -1);
+}
+
+TEST_CASE("H5meta arg get returns matching argument when present") {
+    std::string s = "hello";
+    std::vector<int> v{1, 2, 3};
+    std::string def = "default";
+    std::vector<int> def_v{9, 9};
+
+    auto& ref_s = h5::arg::get<std::string>(def, 7, s, 3.5);
+    auto& ref_v = h5::arg::get<std::vector<int>>(def_v, 7, 3.5, v);
+
+    CHECK((std::is_same_v<decltype(ref_s), std::string&>));
+    CHECK(&ref_s == &s);
+    CHECK(ref_s == "hello");
+
+    CHECK((std::is_same_v<decltype(ref_v), std::vector<int>&>));
+    CHECK(&ref_v == &v);
+    CHECK(ref_v.size() == 3);
+    CHECK(ref_v[0] == 1);
+}
+
+TEST_CASE("H5meta arg get returns default when match is absent") {
+    int i = 1;
+    double d = 2.0;
+    std::string def = "fallback";
+
+    auto& ref = h5::arg::get<std::string>(def, i, d);
+
+    CHECK((std::is_same_v<decltype(ref), const std::string&>));
+    CHECK(&ref == &def);
+    CHECK(ref == "fallback");
+}
+
+TEST_CASE("H5meta arg getn returns nth forwarded argument") {
+    int i = 11;
+    double d = 2.5;
+    std::string s = "abc";
+
+    auto& ref0 = h5::arg::getn<0>(i, d, s);
+    auto& ref1 = h5::arg::getn<1>(i, d, s);
+    auto& ref2 = h5::arg::getn<2>(i, d, s);
+
+    CHECK(&ref0 == &i);
+    CHECK(&ref1 == &d);
+    CHECK(&ref2 == &s);
+}
+
+TEST_CASE("H5meta impl conditional selects correct branch") {
+    CHECK((std::is_same_v<typename h5::impl::conditional<true, int, double>::type, int>));
+    CHECK((std::is_same_v<typename h5::impl::conditional<false, int, double>::type, double>));
+}
+
+TEST_CASE("H5meta impl cat concatenates tuple types") {
+    using lhs_t = std::tuple<int, double>;
+    using rhs_t = std::tuple<char, long>;
+    using result_t = typename h5::impl::cat<lhs_t, rhs_t>::type;
+
+    CHECK((std::is_same_v<result_t, std::tuple<int, double, char, long>>));
+}
+
+TEST_CASE("H5meta impl cat concatenates multiple tuples") {
+    using t0_t = std::tuple<int>;
+    using t1_t = std::tuple<double, char>;
+    using t2_t = std::tuple<long>;
+    using result_t = typename h5::impl::cat<t0_t, t1_t, t2_t>::type;
+
+    CHECK((std::is_same_v<result_t, std::tuple<int, double, char, long>>));
+}
+
+TEST_CASE("H5meta get_extent returns empty array for scalars") {
+    constexpr auto extents = h5::meta::get_extent<int>();
+    CHECK(extents.size() == 0);
+}
+
+TEST_CASE("H5meta get_extent returns 1d extents correctly") {
+    constexpr auto extents = h5::meta::get_extent<int[7]>();
+
+    CHECK(extents.size() == 1);
+    CHECK(extents[0] == 7);
+}
+
+TEST_CASE("H5meta get_extent returns multidimensional extents correctly") {
+    constexpr auto extents = h5::meta::get_extent<double[2][3][4]>();
+
+    CHECK(extents.size() == 3);
+    CHECK(extents[0] == 2);
+    CHECK(extents[1] == 3);
+    CHECK(extents[2] == 4);
+}
+
+TEST_CASE("H5meta extent_to_string formats scalar and array types") {
+    CHECK(std::string(h5::meta::extent_to_string<int>::value) == "int[]");
+    CHECK(std::string(h5::meta::extent_to_string<int[7]>::value) == "int[7]");
+    CHECK(std::string(h5::meta::extent_to_string<int[2][3]>::value) == "int[2,3]");
+    CHECK(std::string(h5::meta::extent_to_string<double[4]>::value) == "double[4]");
+    CHECK(std::string(h5::meta::extent_to_string<unsigned short[5]>::value) == "unsigned short[5]");
+    CHECK(std::string(h5::meta::extent_to_string<long long[2][10]>::value) == "long long[2,10]");
+}
+
+TEST_CASE("H5meta extent_to_string preserves base type naming") {
+    CHECK(std::string(h5::meta::extent_to_string<char[3]>::value) == "char[3]");
+    CHECK(std::string(h5::meta::extent_to_string<short[9]>::value) == "short[9]");
+    CHECK(std::string(h5::meta::extent_to_string<float[8]>::value) == "float[8]");
+    CHECK(std::string(h5::meta::extent_to_string<long double[6]>::value) == "long double[6]");
+}

--- a/test/support/common.hpp
+++ b/test/support/common.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <hdf5.h>
+#include <doctest/all>
+#include <h5cpp/core>
+
+#include "names.hpp"
+#include "types.hpp"
+
+namespace h5::test {
+    template <class T, class...>
+    struct name {
+        static constexpr char const* value = "T";
+    };
+}

--- a/test/support/names.hpp
+++ b/test/support/names.hpp
@@ -1,0 +1,134 @@
+/* Copyright (c) 2018-2020 vargaconsulting, Toronto,ON Canada
+ * Author: Varga, Steven <steven@vargaconsulting.ca>
+ */
+#pragma once
+#include <array>
+#include <vector>
+#include <deque>
+#include <forward_list>
+#include <list>
+#include <set>
+#include <map>
+#include <unordered_set>
+#include <unordered_map>
+#include <stack>
+#include <queue>
+
+namespace h5 {
+	/*
+	template <> struct name<::h5::test::pod_t>{
+		static constexpr char const * value = "pod_t";
+	};
+	template <class T> struct name<separator_t<T>> {
+		static constexpr char const * value = "";
+	};
+*/
+	template <class T, size_t N> struct name<T[N]> {
+		static constexpr char const * value = "T[i]";
+	};
+	template <class T, size_t I, size_t J> struct name<T[I][J]> {
+		static constexpr char const * value = "T[i,j]";
+	};
+	template <class T, size_t I, size_t J, size_t K> struct name<T[I][J][K]> {
+		static constexpr char const * value = "T[i,j,k]";
+	};
+	template <class T, size_t I, size_t J, size_t K, size_t M> struct name<T[I][J][K][M]> {
+		static constexpr char const * value = "T[i,j,k,m]";
+	};
+	template <class T, size_t I, size_t J, size_t K, size_t M, size_t N> struct name<T[I][J][K][M][N]> {
+		static constexpr char const * value = "T[i,j,k,m,n]";
+	};
+
+	template <class T, size_t N> struct name <std::array<T,N>> {
+		static constexpr char const * value = "std::array<T,N>";
+	};
+	template <class T, size_t N> struct name <std::array<std::vector<T>,N>> {
+		static constexpr char const * value = "std::array<std::vector<T>,N>";
+	};
+	template <class T> struct name <std::vector<T>> {
+		static constexpr char const * value = "std::vector<T>";
+	};
+	template <class T> struct name <std::vector<std::vector<T>>> {
+		static constexpr char const * value = "std::vector<std::vector<T>>";
+	};
+	template <class T, size_t N> struct name <std::vector<std::array<T,N>>> {
+		static constexpr char const * value = "std::vector<std::array<T,N>>";
+	};
+
+
+	template <class T> struct name <std::deque<T>> {
+		static constexpr char const * value = "std::deque<T>";
+	};
+	template <class T> struct name <std::forward_list<T>> {
+		static constexpr char const * value = "std::forward_list<T>";
+	};
+	template <class T> struct name <std::list<T>> {
+		static constexpr char const * value = "std::list<T>";
+	};
+	template <class T> struct name <std::set<T>> {
+		static constexpr char const * value = "std::set<T>";
+	};
+	template <class T> struct name <std::multiset<T>> {
+		static constexpr char const * value = "std::multiset<T>";
+	};
+	template <class K, class V> struct name <std::map<K,V>> {
+		static constexpr char const * value = "std::map<K,V>";
+	};
+	template <class K, class V> struct name <std::multimap<K,V>> {
+		static constexpr char const * value = "std::multimap<K,V>";
+	};
+	template <class T> struct name <std::unordered_set<T>> {
+		static constexpr char const * value = "std::unordered_set<T>";
+	};
+	template <class T> struct name <std::unordered_multiset<T>> {
+		static constexpr char const * value = "std::unordered_multiset<T>";
+	};
+	template <class K, class V> struct name <std::unordered_map<K,V>> {
+		static constexpr char const * value = "std::unordered_map<K,V>";
+	};
+	template <class K, class V> struct name <std::unordered_multimap<K,V>> {
+		static constexpr char const * value = "std::unordered_multimap<K,V>";
+	};
+
+	template <class T> struct name <std::stack<T, std::deque<T>>> {
+		static constexpr char const * value = "std::stack<T,deque>";
+	};
+	template <class T> struct name <std::stack<T, std::vector<T>>> {
+		static constexpr char const * value = "std::stack<T,vector>";
+	};
+	template <class T> struct name <std::stack<T, std::list<T>>> {
+		static constexpr char const * value = "std::stack<T,list>";
+	};
+
+
+	template <class T> struct name <std::queue<T, std::deque<T>>> {
+		static constexpr char const * value = "std::queue<T, deque>";
+	};
+	template <class T> struct name <std::queue<T, std::list<T>>> {
+		static constexpr char const * value = "std::queue<T,list>";
+	};
+
+	template <class T> struct name <std::priority_queue<T, std::deque<T>>> {
+		static constexpr char const * value = "std::priority_queue<T,deque>";
+	};
+	template <class T> struct name <std::priority_queue<T, std::list<T>>> {
+		static constexpr char const * value = "std::priority_queue<T,list>";
+	};
+	template <class T> struct name <std::priority_queue<T, std::vector<T>>> {
+		static constexpr char const * value = "std::priority_queue<T,vector>";
+	};
+
+	template <class T>
+	std::vector<std::string> names(){
+		std::vector<std::string> data;
+		h5::meta::static_for<T>( [&]( auto i ) {
+			data.push_back( name<std::tuple_element_t<i,T>>::value);
+		});
+		return data;
+	}
+	struct element_names_t {
+		template <typename T> static std::string GetName(int i) {
+		   return  h5::name<T>::value;
+		 }
+	};
+}

--- a/test/support/pod_t.hpp
+++ b/test/support/pod_t.hpp
@@ -1,0 +1,28 @@
+/* Copyright (c) 2018 vargaconsulting, Toronto,ON Canada
+ *     Author: Varga, Steven <steven@vargaconsulting.ca>
+ */
+
+#ifndef H5CPP_GUARD_WizjK
+#define H5CPP_GUARD_WizjK
+//template specialization of pod_t to create HDF5 COMPOUND type
+template<> h5::dt_t<h5::test::pod_t> inline h5::create<h5::test::pod_t>(){
+
+    h5::dt_t<h5::test::pod_t> ct_00{H5Tcreate(H5T_COMPOUND, sizeof (h5::test::pod_t))};
+    H5Tinsert(ct_00, "a",	HOFFSET(::h5::test::pod_t,a),H5T_NATIVE_INT);
+    H5Tinsert(ct_00, "b",	HOFFSET(::h5::test::pod_t,b),H5T_NATIVE_FLOAT);
+    H5Tinsert(ct_00, "c",	HOFFSET(::h5::test::pod_t,c),H5T_NATIVE_DOUBLE);
+    return ct_00;
+};
+
+template<> h5::dt_t<h5::test::pod_t*> inline h5::create<h5::test::pod_t*>(){
+    return h5::dt_t<h5::test::pod_t*>{ H5Tvlen_create(
+            h5::create<h5::test::pod_t>())};
+};
+template <> struct h5::name <h5::test::pod_t> {
+    static constexpr char const * value = "pod_t";
+};
+template <> struct h5::name <h5::test::pod_t*> {
+    static constexpr char const * value = "pod_t*";
+};
+
+#endif

--- a/test/support/types.hpp
+++ b/test/support/types.hpp
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2019 vargaconsulting, Toronto,ON Canada
+ * Author: Varga, Steven <steven@vargaconsulting.ca>
+ */
+#pragma once
+
+#include <complex>
+#include <array>
+#include <vector>
+#include <deque>
+#include <forward_list>
+#include <list>
+#include <set>
+#include <map>
+#include <unordered_set>
+#include <unordered_map>
+#include <stack>
+#include <queue>
+#include <any>
+#include <h5cpp/H5meta.hpp>
+
+namespace h5::test {
+	template <class T>
+	struct separator_t : std::integral_constant<size_t,3> {
+		T type;
+	};
+
+	template <class T> struct is_separator : std::false_type {};
+	template <class T> struct is_separator<separator_t<T>> : std::true_type {};
+
+    struct pod_t {
+      int    a;
+      float  b;
+      double c;
+    };
+
+
+	/*y axis are element types*/
+	using numerical_t = std::tuple<
+		unsigned char, unsigned short, unsigned int, unsigned long long int,
+		char, short, int, long long int, float, double>;
+	using other_t = std::tuple<pod_t>;
+	using element_t = h5::impl::cat<numerical_t, other_t>::type;
+
+	template <class T, size_t N=1> using array_t = std::tuple< // c like array, same memory size 
+		T, T[N*N*N*N*N],    T[N*N*N][N*N],   T[N*N][N][N*N], T[N][N][N][N*N], T[N][N][N][N][N]>;
+
+	template <class T, size_t N=1> using sequential_t = std::tuple<
+		std::array<T, N>, std::array<std::vector<T>,N>,
+		std::vector<T>, std::vector<std::array<T,N>>,std::vector<std::vector<T>>>;
+
+	template <class T, class K=T, class V=T> using iterable_t = std::tuple<
+		std::deque<T>, std::list<T>, std::forward_list<T>,
+		std::set<T>, std::multiset<T>,
+		std::map<K,V>, std::multimap<K,V>,
+		std::unordered_set<T>, std::unordered_multiset<T>,
+		std::unordered_map<K,V>, std::unordered_multimap<K, V>>;
+
+	template <class T> using adaptor_t = std::tuple<
+		std::stack<T, std::deque<T>>, std::stack<T, std::vector<T>>, std::stack<T, std::list<T>>,
+		std::queue<T, std::deque<T>>, std::queue<T, std::list<T>>,
+		std::priority_queue<T, std::deque<T>>, std::priority_queue<T, std::vector<T>>>;
+
+
+	template <class T=int, class K=T, class V=T, size_t N=1>
+	using stl_t = typename h5::impl::cat<
+		sequential_t<T,N>, iterable_t<T,K,V>, adaptor_t<T>>::type;
+
+	template <class T = int, size_t N = 1>
+	using contigous_t = typename  h5::impl::cat<
+		array_t<T,N>, sequential_t<T,N>>::type;
+
+/*
+	template <class T>
+	using linalg_t = typename h5::impl::cat<
+		armadillo_t<T>,	eigen_t<T>, blitz_t<T>, blaze_t<T>, dlib_t<T>, itpp_t<T>, ublas_t<T>
+		>::type;
+
+	template <class T=int, class K=T, class V=T, size_t N=1>
+	using all_t = typename h5::impl::cat<
+		array_t<T,N>, stl_t<T,K,V,N>, linalg_t<T>>::type;
+
+	template <class T>
+	std::vector<std::string> h5_names(){
+		std::vector<std::string> data;
+		h5::meta::static_for<T>( [&]( auto i ) {
+			data.push_back( h5::name<std::tuple_element_t<i,T>>::value);
+		});
+		return data;
+	}
+*/
+}
+


### PR DESCRIPTION
Refs #94.

Adds Phase A characterization tests for the current master meta/type behavior before the #85–#90 refactor chain.

This PR intentionally characterizes current behavior, including known limitations that will be addressed later:
- nested-container `size()` behavior
- `get<std::string>::ctor` sizing
- `enable_or` / `enable_and` alias behavior

**Test files added:**
- `test/H5compat.cpp` — compatibility layer behavior
- `test/H5meta.cpp` — meta/type-trait behavior
- `test/H5Tmeta.cpp` — HDF5 type metadata behavior
- `test/support/common.hpp`, `names.hpp`, `pod_t.hpp`, `types.hpp` — shared test infrastructure

No production headers modified.

**Stacked on:** `issue/95-doctest` (PR #98)

**Merge order:**
1. Merge PR #97 (`issue/82-modernize-cmake` → `master`)
2. Retarget PR #98 onto `master`, merge
3. Retarget this PR onto `master`, merge