### PR TITLE
refactor: normalize detection idiom usage across meta layer (#85)

### DIFF
--- a/h5cpp/compat.hpp
+++ b/h5cpp/compat.hpp
@@ -38,54 +38,6 @@ namespace h5::compat { // C++11 shim to lower from c++17
     }
 }
 
-namespace h5::impl::compat {
-    struct nonesuch {
-        nonesuch( ) = delete;
-        ~nonesuch( ) = delete;
-        nonesuch( nonesuch const& ) = delete;
-        void operator = ( nonesuch const& ) = delete;
-    };
-
-    template< class... > using void_t = void;
-    namespace detail {
-        template <class Default, class AlwaysVoid,
-                  template<class...> class Op, class... Args>
-        struct detector {
-          using value_t = std::false_type;
-          using type = Default;
-        };
-
-        template <class Default, template<class...> class Op, class... Args>
-        struct detector<Default, std::void_t<Op<Args...>>, Op, Args...> {
-          using value_t = std::true_type;
-          using type = Op<Args...>;
-        };
-    } // namespace detail
-
-    template <template<class...> class Op, class... Args>
-    using is_detected = typename detail::detector<nonesuch, void, Op, Args...>::value_t;
-
-    template <template<class...> class Op, class... Args>
-    using detected_t = typename detail::detector<nonesuch, void, Op, Args...>::type;
-
-    template <class Default, template<class...> class Op, class... Args>
-    using detected_or = detail::detector<Default, void, Op, Args...>;
-
-    // helper templates
-    template< template<class...> class Op, class... Args >
-    constexpr bool is_detected_v = is_detected<Op, Args...>::value;
-    template< class Default, template<class...> class Op, class... Args >
-    using detected_or_t = typename detected_or<Default, Op, Args...>::type;
-    template <class Expected, template<class...> class Op, class... Args>
-    using is_detected_exact = std::is_same<Expected, detected_t<Op, Args...>>;
-    template <class Expected, template<class...> class Op, class... Args>
-    constexpr bool is_detected_exact_v = is_detected_exact<Expected, Op, Args...>::value;
-    template <class To, template<class...> class Op, class... Args>
-    using is_detected_convertible = std::is_convertible<detected_t<Op, Args...>, To>;
-    template <class To, template<class...> class Op, class... Args>
-    constexpr bool is_detected_convertible_v = is_detected_convertible<To, Op, Args...>::value;
-}
-
 namespace h5::meta::compat {
 // N4436 and https://en.cppreference.com/w/cpp/experimental/is_detected 
     struct nonesuch {
@@ -105,7 +57,7 @@ namespace h5::meta::compat {
         };
 
         template <class Default, template<class...> class Op, class... Args>
-        struct detector<Default, std::void_t<Op<Args...>>, Op, Args...> {
+        struct detector<Default, void_t<Op<Args...>>, Op, Args...> {
           using value_t = std::true_type;
           using type = Op<Args...>;
         };


### PR DESCRIPTION
## Summary
- Remove the unused `h5::impl::compat` detection-idiom copy from
  `h5cpp/compat.hpp`. It was defined but never referenced anywhere
  in the project.
- Inside `h5::meta::compat::detail::detector`, use the local
  `void_t` alias instead of `std::void_t` for self-consistency
  with the alias declared in the same namespace.

## Scope
- C++17 stabilization only. C++20/C++23 modernization deferred.
- Single file changed: `h5cpp/compat.hpp` (-49, +1).
- No public `h5::meta::compat` API names changed.
- `H5meta.hpp` and `H5Tmeta.hpp` untouched.
- No new `H5Ttraits.hpp`, `storage_t`, `shape_t`, `access_t`,
  or recursive contiguity work.

## Test plan
- [x] `cmake --build build --parallel` — clean
- [x] `ctest --test-dir build --output-on-failure` — 4/4 pass