### PR TITLE
refactor: add capability-based type families to H5Tmeta.hpp (#86)

### DIFF
--- a/h5cpp/H5Tmeta.hpp
+++ b/h5cpp/H5Tmeta.hpp
@@ -89,6 +89,112 @@ namespace h5::meta {
     template <class T, class... Ts> struct is_linalg : std::false_type {};
     template <class C, class T, class... Cs> struct is_valid : std::false_type {};
 
+    // ------------------------------------------------------------
+    // Capability-based type families (#86)
+    // Additive predicate vocabulary used by the upcoming #87/#88/#89/#90
+    // refactors. Predicates only; no storage/shape/access traits, no recursive
+    // contiguity, no datatype synthesis, no dataset I/O changes. C++17 floor.
+    // Reuses existing detection primitives from H5meta.hpp; does not redeclare
+    // has_data, has_size, has_direct_access, has_value_type, has_iterator,
+    // or has_const_iterator.
+    // ------------------------------------------------------------
+
+    template <class T> using remove_cvref_t = std::remove_cv_t<std::remove_reference_t<T>>;
+
+    // Internal expression-detector aliases (consistent with H5meta.hpp `_f` style)
+    template <class T> using key_type_f    = typename T::key_type;
+    template <class T> using mapped_type_f = typename T::mapped_type;
+    template <class T> using key_compare_f = typename T::key_compare;
+    template <class T> using hasher_f      = typename T::hasher;
+    template <class T> using resize_f      = decltype(std::declval<T&>().resize(std::declval<std::size_t>()));
+
+    // text-like
+    template <class T> struct is_fixed_text_like : std::false_type {};
+    template <std::size_t N> struct is_fixed_text_like<char[N]>       : std::true_type {};
+    template <std::size_t N> struct is_fixed_text_like<const char[N]> : std::true_type {};
+
+    template <class T> struct is_vl_text_like : std::false_type {};
+    template <> struct is_vl_text_like<char*>       : std::true_type {};
+    template <> struct is_vl_text_like<const char*> : std::true_type {};
+    template <class Tr> struct is_vl_text_like<std::basic_string_view<char, Tr>> : std::true_type {};
+    template <class Tr, class A> struct is_vl_text_like<std::basic_string<char, Tr, A>> : std::true_type {};
+
+    template <class T> struct is_text_like
+        : std::bool_constant<is_fixed_text_like<remove_cvref_t<T>>::value
+                          || is_vl_text_like<remove_cvref_t<T>>::value> {};
+
+    // array-like (built-in arrays + std::array, cv/ref-stable)
+    namespace detail_capabilities {
+        template <class T> struct is_array_like_impl : std::false_type {};
+        template <class T, std::size_t N> struct is_array_like_impl<T[N]>            : std::true_type {};
+        template <class T, std::size_t N> struct is_array_like_impl<std::array<T,N>> : std::true_type {};
+    }
+    template <class T> struct is_array_like
+        : detail_capabilities::is_array_like_impl<remove_cvref_t<T>> {};
+
+    // iterable — derived from existing has_iterator (begin && end)
+    template <class T> struct is_iterable : has_iterator<remove_cvref_t<T>> {};
+
+    // resizable
+    template <class T> struct is_resizable : compat::is_detected<resize_f, remove_cvref_t<T>> {};
+
+    // sequential / associative / unordered / set / map / stl_like
+    // Text-like types (std::string, string_view) are excluded so they remain
+    // classified under is_text_like rather than leaking into is_stl_like.
+    template <class T> struct is_sequential_like
+        : std::bool_constant<is_iterable<T>::value
+                          && compat::is_detected<value_type_f,  remove_cvref_t<T>>::value
+                          && !compat::is_detected<key_type_f,    remove_cvref_t<T>>::value
+                          && !compat::is_detected<mapped_type_f, remove_cvref_t<T>>::value
+                          && !is_text_like<T>::value> {};
+
+    template <class T> struct is_associative_like
+        : std::bool_constant<is_iterable<T>::value
+                          && compat::is_detected<key_type_f,    remove_cvref_t<T>>::value
+                          && compat::is_detected<key_compare_f, remove_cvref_t<T>>::value> {};
+
+    template <class T> struct is_unordered_like
+        : std::bool_constant<is_iterable<T>::value
+                          && compat::is_detected<key_type_f, remove_cvref_t<T>>::value
+                          && compat::is_detected<hasher_f,   remove_cvref_t<T>>::value> {};
+
+    template <class T> struct is_set_like
+        : std::bool_constant<compat::is_detected<key_type_f,    remove_cvref_t<T>>::value
+                          && compat::is_detected<value_type_f,  remove_cvref_t<T>>::value
+                          && !compat::is_detected<mapped_type_f, remove_cvref_t<T>>::value> {};
+
+    template <class T> struct is_map_like
+        : std::bool_constant<compat::is_detected<key_type_f,    remove_cvref_t<T>>::value
+                          && compat::is_detected<mapped_type_f, remove_cvref_t<T>>::value
+                          && compat::is_detected<value_type_f,  remove_cvref_t<T>>::value> {};
+
+    template <class T> struct is_stl_like
+        : std::bool_constant<is_sequential_like<T>::value
+                          || is_associative_like<T>::value
+                          || is_unordered_like<T>::value> {};
+
+    // enumerated / bitfield / opaque
+    template <class T> struct is_enumerated_like : std::is_enum<remove_cvref_t<T>> {};
+
+    template <class T> struct is_bitfield_like : std::false_type {};
+    template <class A> struct is_bitfield_like<std::vector<bool, A>> : std::true_type {};
+
+    template <class T> struct is_opaque_like : std::false_type {};
+    template <> struct is_opaque_like<void*>        : std::true_type {};
+    template <> struct is_opaque_like<const void*>  : std::true_type {};
+    template <> struct is_opaque_like<void**>       : std::true_type {};
+    template <> struct is_opaque_like<const void**> : std::true_type {};
+
+    // strict pointer-data capability:
+    //   true iff T::data() exists AND its return type is a pointer.
+    // Distinct from has_direct_access (which only detects existence of .data()).
+    template <class T> struct has_data_pointer
+        : std::bool_constant<std::is_pointer_v<
+              compat::detected_or_t<void, data_f, remove_cvref_t<T>>>> {};
+    // ------------------------------------------------------------
+    // End capability-based type families (#86)
+    // ------------------------------------------------------------
+
     // DEFAULT CASE
     template <class T> struct rank<T*>: public std::integral_constant<size_t,1>{};
     template <class T, class... Ts>

--- a/test/H5Tmeta.cpp
+++ b/test/H5Tmeta.cpp
@@ -5,11 +5,18 @@
 #include <h5cpp/H5Tmeta.hpp>
 #include <array>
 #include <complex>
+#include <deque>
+#include <forward_list>
 #include <initializer_list>
+#include <list>
+#include <map>
+#include <set>
 #include <string>
 #include <string_view>
 #include <tuple>
 #include <type_traits>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 
@@ -52,6 +59,9 @@ struct sized_value_t {
 struct value_type_only_t {
     using value_type = int;
 };
+
+enum capability_enum_unscoped { capability_enum_unscoped_a, capability_enum_unscoped_b };
+enum class capability_enum_scoped { a, b };
 
 TEST_CASE("H5Tmeta is_array detects C arrays and std::array") {
     CHECK(h5::meta::is_array<int[4]>::value);
@@ -388,4 +398,180 @@ TEST_CASE("H5Tmeta get_fields helpers are no-op and callable") {
     h5::meta::get_field_attributes(pod);
 
     CHECK(true);
+}
+
+// ============================================================
+// Capability-based type families (#86) — characterization tests
+// ============================================================
+
+TEST_CASE("H5Tmeta is_text_like covers char arrays pointers and string family") {
+    CHECK(h5::meta::is_text_like<char[5]>::value);
+    CHECK(h5::meta::is_text_like<const char[5]>::value);
+    CHECK(h5::meta::is_text_like<char*>::value);
+    CHECK(h5::meta::is_text_like<const char*>::value);
+    CHECK(h5::meta::is_text_like<std::string>::value);
+    CHECK(h5::meta::is_text_like<std::string_view>::value);
+
+    CHECK_FALSE(h5::meta::is_text_like<wchar_t[5]>::value);
+    CHECK_FALSE(h5::meta::is_text_like<int>::value);
+    CHECK_FALSE(h5::meta::is_text_like<std::vector<char>>::value);
+}
+
+TEST_CASE("H5Tmeta is_fixed_text_like detects char arrays only") {
+    CHECK(h5::meta::is_fixed_text_like<char[5]>::value);
+    CHECK(h5::meta::is_fixed_text_like<const char[5]>::value);
+
+    CHECK_FALSE(h5::meta::is_fixed_text_like<char*>::value);
+    CHECK_FALSE(h5::meta::is_fixed_text_like<std::string>::value);
+    CHECK_FALSE(h5::meta::is_fixed_text_like<std::string_view>::value);
+}
+
+TEST_CASE("H5Tmeta is_vl_text_like detects char pointers and string family") {
+    CHECK(h5::meta::is_vl_text_like<char*>::value);
+    CHECK(h5::meta::is_vl_text_like<const char*>::value);
+    CHECK(h5::meta::is_vl_text_like<std::string>::value);
+    CHECK(h5::meta::is_vl_text_like<std::string_view>::value);
+
+    CHECK_FALSE(h5::meta::is_vl_text_like<char[5]>::value);
+    CHECK_FALSE(h5::meta::is_vl_text_like<int>::value);
+}
+
+TEST_CASE("H5Tmeta is_array_like covers built-in arrays and std array cv ref stable") {
+    CHECK(h5::meta::is_array_like<int[3]>::value);
+    CHECK(h5::meta::is_array_like<std::array<int, 4>>::value);
+    CHECK(h5::meta::is_array_like<int(&)[3]>::value);
+    CHECK(h5::meta::is_array_like<const int[3]>::value);
+    CHECK((h5::meta::is_array_like<const std::array<int, 4>>::value));
+    CHECK((h5::meta::is_array_like<std::array<int, 4>&>::value));
+
+    CHECK_FALSE(h5::meta::is_array_like<int>::value);
+    CHECK_FALSE(h5::meta::is_array_like<std::vector<int>>::value);
+    CHECK_FALSE((h5::meta::is_array_like<int*>::value));
+}
+
+TEST_CASE("H5Tmeta is_iterable detects begin and end") {
+    CHECK(h5::meta::is_iterable<std::vector<int>>::value);
+    CHECK(h5::meta::is_iterable<std::string>::value);
+    CHECK(h5::meta::is_iterable<std::set<int>>::value);
+    CHECK((h5::meta::is_iterable<std::map<int, int>>::value));
+    CHECK(h5::meta::is_iterable<iterable_value_t>::value);
+
+    CHECK_FALSE(h5::meta::is_iterable<int>::value);
+    CHECK_FALSE(h5::meta::is_iterable<pod_value_t>::value);
+    CHECK_FALSE(h5::meta::is_iterable<sized_value_t>::value);
+}
+
+TEST_CASE("H5Tmeta is_resizable detects resize size_t method") {
+    CHECK(h5::meta::is_resizable<std::vector<int>>::value);
+    CHECK(h5::meta::is_resizable<std::string>::value);
+
+    CHECK_FALSE((h5::meta::is_resizable<std::array<int, 4>>::value));
+    CHECK_FALSE(h5::meta::is_resizable<int>::value);
+    CHECK_FALSE(h5::meta::is_resizable<std::set<int>>::value);
+}
+
+TEST_CASE("H5Tmeta is_sequential_like covers vector deque list forward_list array") {
+    CHECK(h5::meta::is_sequential_like<std::vector<int>>::value);
+    CHECK(h5::meta::is_sequential_like<std::deque<int>>::value);
+    CHECK(h5::meta::is_sequential_like<std::list<int>>::value);
+    CHECK(h5::meta::is_sequential_like<std::forward_list<int>>::value);
+    CHECK((h5::meta::is_sequential_like<std::array<int, 4>>::value));
+
+    CHECK_FALSE(h5::meta::is_sequential_like<std::set<int>>::value);
+    CHECK_FALSE((h5::meta::is_sequential_like<std::map<int, int>>::value));
+    CHECK_FALSE(h5::meta::is_sequential_like<int>::value);
+
+    // text-like types remain text-like, not sequential-like
+    CHECK_FALSE(h5::meta::is_sequential_like<std::string>::value);
+    CHECK_FALSE(h5::meta::is_stl_like<std::string>::value);
+    CHECK(h5::meta::is_text_like<std::string>::value);
+}
+
+TEST_CASE("H5Tmeta is_associative_like covers ordered set and map family") {
+    CHECK(h5::meta::is_associative_like<std::set<int>>::value);
+    CHECK((h5::meta::is_associative_like<std::map<int, int>>::value));
+    CHECK(h5::meta::is_associative_like<std::multiset<int>>::value);
+    CHECK((h5::meta::is_associative_like<std::multimap<int, int>>::value));
+
+    CHECK_FALSE(h5::meta::is_associative_like<std::unordered_set<int>>::value);
+    CHECK_FALSE(h5::meta::is_associative_like<std::vector<int>>::value);
+}
+
+TEST_CASE("H5Tmeta is_unordered_like covers unordered set and map family") {
+    CHECK(h5::meta::is_unordered_like<std::unordered_set<int>>::value);
+    CHECK((h5::meta::is_unordered_like<std::unordered_map<int, int>>::value));
+    CHECK(h5::meta::is_unordered_like<std::unordered_multiset<int>>::value);
+    CHECK((h5::meta::is_unordered_like<std::unordered_multimap<int, int>>::value));
+
+    CHECK_FALSE(h5::meta::is_unordered_like<std::set<int>>::value);
+    CHECK_FALSE(h5::meta::is_unordered_like<std::vector<int>>::value);
+}
+
+TEST_CASE("H5Tmeta is_set_like distinguishes sets from maps and sequences") {
+    CHECK(h5::meta::is_set_like<std::set<int>>::value);
+    CHECK(h5::meta::is_set_like<std::multiset<int>>::value);
+    CHECK(h5::meta::is_set_like<std::unordered_set<int>>::value);
+    CHECK(h5::meta::is_set_like<std::unordered_multiset<int>>::value);
+
+    CHECK_FALSE((h5::meta::is_set_like<std::map<int, int>>::value));
+    CHECK_FALSE(h5::meta::is_set_like<std::vector<int>>::value);
+}
+
+TEST_CASE("H5Tmeta is_map_like distinguishes maps from sets and sequences") {
+    CHECK((h5::meta::is_map_like<std::map<int, int>>::value));
+    CHECK((h5::meta::is_map_like<std::multimap<int, int>>::value));
+    CHECK((h5::meta::is_map_like<std::unordered_map<int, int>>::value));
+    CHECK((h5::meta::is_map_like<std::unordered_multimap<int, int>>::value));
+
+    CHECK_FALSE(h5::meta::is_map_like<std::set<int>>::value);
+    CHECK_FALSE(h5::meta::is_map_like<std::vector<int>>::value);
+}
+
+TEST_CASE("H5Tmeta is_stl_like is union of sequential associative and unordered") {
+    CHECK(h5::meta::is_stl_like<std::vector<int>>::value);
+    CHECK(h5::meta::is_stl_like<std::list<int>>::value);
+    CHECK(h5::meta::is_stl_like<std::set<int>>::value);
+    CHECK((h5::meta::is_stl_like<std::map<int, int>>::value));
+    CHECK((h5::meta::is_stl_like<std::unordered_map<int, int>>::value));
+
+    CHECK_FALSE(h5::meta::is_stl_like<int>::value);
+    CHECK_FALSE(h5::meta::is_stl_like<pod_value_t>::value);
+    CHECK_FALSE(h5::meta::is_stl_like<int[3]>::value);
+}
+
+TEST_CASE("H5Tmeta is_enumerated_like detects scoped and unscoped enums") {
+    CHECK(h5::meta::is_enumerated_like<capability_enum_unscoped>::value);
+    CHECK(h5::meta::is_enumerated_like<capability_enum_scoped>::value);
+
+    CHECK_FALSE(h5::meta::is_enumerated_like<int>::value);
+    CHECK_FALSE(h5::meta::is_enumerated_like<bool>::value);
+}
+
+TEST_CASE("H5Tmeta is_bitfield_like detects vector of bool") {
+    CHECK(h5::meta::is_bitfield_like<std::vector<bool>>::value);
+
+    CHECK_FALSE(h5::meta::is_bitfield_like<std::vector<int>>::value);
+    CHECK_FALSE(h5::meta::is_bitfield_like<bool>::value);
+    CHECK_FALSE(h5::meta::is_bitfield_like<int>::value);
+}
+
+TEST_CASE("H5Tmeta is_opaque_like detects void pointer family") {
+    CHECK(h5::meta::is_opaque_like<void*>::value);
+    CHECK(h5::meta::is_opaque_like<const void*>::value);
+    CHECK(h5::meta::is_opaque_like<void**>::value);
+    CHECK(h5::meta::is_opaque_like<const void**>::value);
+
+    CHECK_FALSE(h5::meta::is_opaque_like<int*>::value);
+    CHECK_FALSE(h5::meta::is_opaque_like<char*>::value);
+}
+
+TEST_CASE("H5Tmeta has_data_pointer is strict pointer-returning data method") {
+    CHECK(h5::meta::has_data_pointer<std::vector<int>>::value);
+    CHECK((h5::meta::has_data_pointer<std::array<int, 4>>::value));
+    CHECK(h5::meta::has_data_pointer<std::string>::value);
+
+    CHECK_FALSE(h5::meta::has_data_pointer<std::list<int>>::value);
+    CHECK_FALSE(h5::meta::has_data_pointer<std::set<int>>::value);
+    CHECK_FALSE((h5::meta::has_data_pointer<std::map<int, int>>::value));
+    CHECK_FALSE(h5::meta::has_data_pointer<int>::value);
 }


### PR DESCRIPTION
## Summary
- Add C++17-compatible capability predicates to `h5cpp/H5Tmeta.hpp`.
- Keep the existing meta predicates and production call sites unchanged.
- Add doctest coverage for the new type-family vocabulary.

## New predicates
- `is_text_like`
- `is_fixed_text_like`
- `is_vl_text_like`
- `is_array_like`
- `is_iterable`
- `is_resizable`
- `is_sequential_like`
- `is_associative_like`
- `is_unordered_like`
- `is_set_like`
- `is_map_like`
- `is_stl_like`
- `is_enumerated_like`
- `is_bitfield_like`
- `is_opaque_like`
- `has_data_pointer`

## Scope
- C++17 stabilization only.
- No C++23 concepts.
- No `H5Ttraits.hpp`.
- No `storage_t`, `shape_t`, or `access_t`.
- No recursive contiguity.
- No datatype synthesis.
- No dataset read/write/create changes.
- No production caller changes.

## Test plan
- [x] `cmake --build build --parallel`
- [x] `ctest --test-dir build --output-on-failure`
- [x] `./build/test-h5tmeta --reporters=console`