### PR TITLE
refactor: add storage representation categories (#88)

### DIFF
--- a/h5cpp/H5Tmeta.hpp
+++ b/h5cpp/H5Tmeta.hpp
@@ -195,6 +195,69 @@ namespace h5::meta {
     // End capability-based type families (#86)
     // ------------------------------------------------------------
 
+    // ------------------------------------------------------------
+    // Storage representation categories (#88)
+    // Representation vocabulary only; no access/materialization strategy,
+    // datatype synthesis, or dataset I/O dispatch.
+    // ------------------------------------------------------------
+
+    enum class storage_representation_t {
+        unsupported,
+        linear_value_dataset,
+        key_value_dataset,
+        ragged_vlen_dataset,
+        fixed_inner_extent_dataset,
+        vlen_text_dataset
+    };
+
+    namespace detail_capabilities {
+    template <class T> struct storage_representation_impl
+        : std::integral_constant<storage_representation_t, storage_representation_t::unsupported> {};
+
+    template <class T, class A> struct storage_representation_impl<std::deque<T,A>>
+        : std::integral_constant<storage_representation_t, storage_representation_t::linear_value_dataset> {};
+    template <class T, class A> struct storage_representation_impl<std::list<T,A>>
+        : std::integral_constant<storage_representation_t, storage_representation_t::linear_value_dataset> {};
+    template <class T, class A> struct storage_representation_impl<std::forward_list<T,A>>
+        : std::integral_constant<storage_representation_t, storage_representation_t::linear_value_dataset> {};
+    template <class T, class C, class A> struct storage_representation_impl<std::set<T,C,A>>
+        : std::integral_constant<storage_representation_t, storage_representation_t::linear_value_dataset> {};
+    template <class T, class C, class A> struct storage_representation_impl<std::multiset<T,C,A>>
+        : std::integral_constant<storage_representation_t, storage_representation_t::linear_value_dataset> {};
+    template <class T, class H, class E, class A> struct storage_representation_impl<std::unordered_set<T,H,E,A>>
+        : std::integral_constant<storage_representation_t, storage_representation_t::linear_value_dataset> {};
+    template <class T, class H, class E, class A> struct storage_representation_impl<std::unordered_multiset<T,H,E,A>>
+        : std::integral_constant<storage_representation_t, storage_representation_t::linear_value_dataset> {};
+
+    template <class K, class V, class C, class A> struct storage_representation_impl<std::map<K,V,C,A>>
+        : std::integral_constant<storage_representation_t, storage_representation_t::key_value_dataset> {};
+    template <class K, class V, class C, class A> struct storage_representation_impl<std::multimap<K,V,C,A>>
+        : std::integral_constant<storage_representation_t, storage_representation_t::key_value_dataset> {};
+    template <class K, class V, class H, class E, class A> struct storage_representation_impl<std::unordered_map<K,V,H,E,A>>
+        : std::integral_constant<storage_representation_t, storage_representation_t::key_value_dataset> {};
+    template <class K, class V, class H, class E, class A> struct storage_representation_impl<std::unordered_multimap<K,V,H,E,A>>
+        : std::integral_constant<storage_representation_t, storage_representation_t::key_value_dataset> {};
+
+    template <class T, class A0, class A1> struct storage_representation_impl<std::vector<std::vector<T,A0>,A1>>
+        : std::integral_constant<storage_representation_t,
+              (!is_text_like<T>::value && !is_stl_like<T>::value)
+                  ? storage_representation_t::ragged_vlen_dataset
+                  : storage_representation_t::unsupported> {};
+    template <class Tr, class A0, class A1> struct storage_representation_impl<std::vector<std::basic_string<char, Tr, A0>,A1>>
+        : std::integral_constant<storage_representation_t, storage_representation_t::vlen_text_dataset> {};
+    template <class T, std::size_t N, class A> struct storage_representation_impl<std::vector<std::array<T,N>,A>>
+        : std::integral_constant<storage_representation_t, storage_representation_t::fixed_inner_extent_dataset> {};
+    }
+
+    template <class T> struct storage_representation
+        : detail_capabilities::storage_representation_impl<remove_cvref_t<T>> {};
+
+    template <class T> constexpr storage_representation_t storage_representation_v =
+        storage_representation<T>::value;
+    // ------------------------------------------------------------
+    // End storage representation categories (#88)
+    // ------------------------------------------------------------
+
     // DEFAULT CASE
     template <class T> struct rank<T*>: public std::integral_constant<size_t,1>{};
     template <class T, class... Ts>

--- a/test/H5Tmeta.cpp
+++ b/test/H5Tmeta.cpp
@@ -575,3 +575,47 @@ TEST_CASE("H5Tmeta has_data_pointer is strict pointer-returning data method") {
     CHECK_FALSE((h5::meta::has_data_pointer<std::map<int, int>>::value));
     CHECK_FALSE(h5::meta::has_data_pointer<int>::value);
 }
+
+TEST_CASE("H5Tmeta storage_representation classifies sequential non-contiguous containers as linear value datasets") {
+    CHECK(h5::meta::storage_representation_v<std::list<int>> == h5::meta::storage_representation_t::linear_value_dataset);
+    CHECK((h5::meta::storage_representation<const std::list<int>&>::value == h5::meta::storage_representation_t::linear_value_dataset));
+    CHECK(h5::meta::storage_representation_v<std::forward_list<int>> == h5::meta::storage_representation_t::linear_value_dataset);
+    CHECK(h5::meta::storage_representation_v<std::deque<int>> == h5::meta::storage_representation_t::linear_value_dataset);
+}
+
+TEST_CASE("H5Tmeta storage_representation classifies ordered set containers as linear value datasets") {
+    CHECK(h5::meta::storage_representation_v<std::set<int>> == h5::meta::storage_representation_t::linear_value_dataset);
+    CHECK(h5::meta::storage_representation_v<std::multiset<int>> == h5::meta::storage_representation_t::linear_value_dataset);
+}
+
+TEST_CASE("H5Tmeta storage_representation classifies unordered set containers as unordered linear value datasets") {
+    CHECK(h5::meta::storage_representation_v<std::unordered_set<int>> == h5::meta::storage_representation_t::linear_value_dataset);
+    CHECK(h5::meta::storage_representation_v<std::unordered_multiset<int>> == h5::meta::storage_representation_t::linear_value_dataset);
+}
+
+TEST_CASE("H5Tmeta storage_representation classifies ordered map containers as key value record datasets") {
+    CHECK((h5::meta::storage_representation_v<std::map<int, double>> == h5::meta::storage_representation_t::key_value_dataset));
+    CHECK((h5::meta::storage_representation_v<std::multimap<int, double>> == h5::meta::storage_representation_t::key_value_dataset));
+}
+
+TEST_CASE("H5Tmeta storage_representation classifies unordered map containers as unordered key value record datasets") {
+    CHECK((h5::meta::storage_representation_v<std::unordered_map<int, double>> == h5::meta::storage_representation_t::key_value_dataset));
+    CHECK((h5::meta::storage_representation_v<std::unordered_multimap<int, double>> == h5::meta::storage_representation_t::key_value_dataset));
+}
+
+TEST_CASE("H5Tmeta storage_representation classifies nested vector containers") {
+    CHECK((h5::meta::storage_representation_v<std::vector<std::vector<int>>> == h5::meta::storage_representation_t::ragged_vlen_dataset));
+    CHECK((h5::meta::storage_representation_v<std::vector<std::vector<double>>> == h5::meta::storage_representation_t::ragged_vlen_dataset));
+    CHECK((h5::meta::storage_representation_v<std::vector<std::vector<std::string>>> == h5::meta::storage_representation_t::unsupported));
+    CHECK((h5::meta::storage_representation_v<std::vector<std::vector<std::vector<int>>>> == h5::meta::storage_representation_t::unsupported));
+    CHECK((h5::meta::storage_representation_v<std::vector<std::string>> == h5::meta::storage_representation_t::vlen_text_dataset));
+    CHECK((h5::meta::storage_representation_v<std::vector<std::array<int, 3>>> == h5::meta::storage_representation_t::fixed_inner_extent_dataset));
+}
+
+TEST_CASE("H5Tmeta storage_representation leaves bitfield and opaque pointer storage unsupported") {
+    CHECK(h5::meta::storage_representation_v<std::vector<bool>> == h5::meta::storage_representation_t::unsupported);
+    CHECK(h5::meta::storage_representation_v<void*> == h5::meta::storage_representation_t::unsupported);
+    CHECK(h5::meta::storage_representation_v<const void*> == h5::meta::storage_representation_t::unsupported);
+    CHECK(h5::meta::storage_representation_v<void**> == h5::meta::storage_representation_t::unsupported);
+    CHECK(h5::meta::storage_representation_v<const void**> == h5::meta::storage_representation_t::unsupported);
+}


### PR DESCRIPTION
## Summary
- Add `storage_representation_t`, `storage_representation<T>`, and
  `storage_representation_v<T>` to `h5cpp/H5Tmeta.hpp`.
- Classify STL-like container families into storage representation
  categories.
- Add doctest coverage for the new representation vocabulary.

## Representation categories
- `unsupported`
- `linear_value_dataset`
- `key_value_dataset`
- `ragged_vlen_dataset`
- `fixed_inner_extent_dataset`
- `vlen_text_dataset`

## Scope
- C++17-compatible representation vocabulary only.
- No dataset read/write/create changes.
- No gather/materialize implementation.
- No datatype synthesis.
- No `H5Ttraits.hpp`.
- No `storage_t`, `shape_t`, or `access_t`.
- No C++23 concepts.
- No CMake/docs changes.

## Test plan
- [x] `cmake --build build --parallel`
- [x] `ctest --test-dir build --output-on-failure`
- [x] `./build/test-h5tmeta --reporters=console`