### PR TITLE
refactor: add gather materialize helpers (#90)

### DIFF
--- a/h5cpp/H5Dgather.hpp
+++ b/h5cpp/H5Dgather.hpp
@@ -5,30 +5,101 @@
 #ifndef  H5CPP_DGATHER_HPP 
 #define  H5CPP_DGATHER_HPP
 
+#include <cstddef>
 #include <vector>
 #include <string>
-#include <iostream> 
+#include <deque>
+#include <forward_list>
+#include <list>
+#include <set>
+#include <type_traits>
+#include <unordered_set>
 #include <string.h>
 
 namespace h5 {
-
-    /** @brief gathers memory regions into a single set of pointers
-     * Objects may be classified by whether the content resides in contiguous memory location, making convenient
-     * to IO operation: only single call is needed; or scattered and we need a reliable mechanism to collect the 
-     * content. <br/>
-     * `h5::gather` is a template mechanism to facilitate the latter process by finding and returning a set of 
-     * `element_t` type pointers to the actual content of an object.  
-     * @param ref arbitrary object with non-contiguous content
-     * @param ptr element type pointer with the correct size respect to `ref` object
-     * @return ptr the same `element_t` pointer passed to the call 
-     * @tparam T C++ type of dataset being written into HDF5 container
-     */ 
-    template <class T, class E> inline
-    const E** gather(const T& ref, std::vector<const E*>& ptrs) {
-        std::cout <<"< +++++++++ >\n";
-
-        return ptrs.data();
+    namespace detail {
+        template <class...> struct dependent_false_t : std::false_type {};
     }
+
+    template <class container_t, class T> inline
+    const T* gather_linear_values(const container_t& ref, std::vector<T>& elements) {
+        elements.clear();
+        elements.insert(elements.end(), ref.begin(), ref.end());
+        return elements.data();
+    }
+
+    template <class T, class A> inline
+    const T* gather(const std::list<T,A>& ref, std::vector<T>& elements){
+        return gather_linear_values(ref, elements);
+    }
+    template <class T, class A> inline
+    const T* gather(const std::forward_list<T,A>& ref, std::vector<T>& elements){
+        return gather_linear_values(ref, elements);
+    }
+    template <class T, class A> inline
+    const T* gather(const std::deque<T,A>& ref, std::vector<T>& elements){
+        return gather_linear_values(ref, elements);
+    }
+    template <class T, class C, class A> inline
+    const T* gather(const std::set<T,C,A>& ref, std::vector<T>& elements){
+        return gather_linear_values(ref, elements);
+    }
+    template <class T, class C, class A> inline
+    const T* gather(const std::multiset<T,C,A>& ref, std::vector<T>& elements){
+        return gather_linear_values(ref, elements);
+    }
+    template <class T, class H, class E, class A> inline
+    const T* gather(const std::unordered_set<T,H,E,A>& ref, std::vector<T>& elements){
+        return gather_linear_values(ref, elements);
+    }
+    template <class T, class H, class E, class A> inline
+    const T* gather(const std::unordered_multiset<T,H,E,A>& ref, std::vector<T>& elements){
+        return gather_linear_values(ref, elements);
+    }
+
+    template <class T, class A> inline
+    void materialize(std::list<T,A>& ref, const T* first, const T* last){
+        ref.assign(first, last);
+    }
+    template <class T, class A> inline
+    void materialize(std::list<T,A>& ref, const T* ptr, size_t size){
+        materialize(ref, ptr, ptr + size);
+    }
+    template <class T, class A> inline
+    void materialize(std::forward_list<T,A>& ref, const T* first, const T* last){
+        ref.assign(first, last);
+    }
+    template <class T, class A> inline
+    void materialize(std::forward_list<T,A>& ref, const T* ptr, size_t size){
+        materialize(ref, ptr, ptr + size);
+    }
+    template <class T, class A> inline
+    void materialize(std::deque<T,A>& ref, const T* first, const T* last){
+        ref.assign(first, last);
+    }
+    template <class T, class A> inline
+    void materialize(std::deque<T,A>& ref, const T* ptr, size_t size){
+        materialize(ref, ptr, ptr + size);
+    }
+    template <class T, class C, class A> inline
+    void materialize(std::set<T,C,A>& ref, const T* first, const T* last){
+        ref.clear();
+        ref.insert(first, last);
+    }
+    template <class T, class C, class A> inline
+    void materialize(std::set<T,C,A>& ref, const T* ptr, size_t size){
+        materialize(ref, ptr, ptr + size);
+    }
+    template <class T, class H, class E, class A> inline
+    void materialize(std::unordered_set<T,H,E,A>& ref, const T* first, const T* last){
+        ref.clear();
+        ref.insert(first, last);
+    }
+    template <class T, class H, class E, class A> inline
+    void materialize(std::unordered_set<T,H,E,A>& ref, const T* ptr, size_t size){
+        materialize(ref, ptr, ptr + size);
+    }
+
     /** @brief gathers memory regions into a single set of pointers
      * Objects may be classified by whether the content resides in contiguous memory location, making convenient
      * to IO operation: only single call is needed; or scattered and we need a reliable mechanism to collect the 
@@ -40,11 +111,30 @@ namespace h5 {
      * @return ptr the same `element_t` pointer passed to the call 
      * @tparam T C++ type of dataset being written into HDF5 container
      */ 
-    template <> inline
-    const char** gather<std::vector<std::string>>( const std::vector<std::string>& ref, std::vector<const char*>& ptrs){
-        for(auto& element: ref) 
+    inline const char** gather( const std::vector<std::string>& ref, std::vector<const char*>& ptrs){
+        ptrs.clear();
+        for(auto& element: ref)
            ptrs.push_back(element.data());
         return ptrs.data();
     } 
+
+    template <class T, class E> inline
+    const E* gather(const T&, std::vector<E>&){
+        static_assert(detail::dependent_false_t<T,E>::value,
+            "h5::gather path is unsupported for this type");
+        return nullptr;
+    }
+
+    template <class T, class E> inline
+    void materialize(T&, const E*, const E*){
+        static_assert(detail::dependent_false_t<T,E>::value,
+            "h5::materialize path is unsupported for this type");
+    }
+
+    template <class T, class E> inline
+    void materialize(T&, const E*, size_t){
+        static_assert(detail::dependent_false_t<T,E>::value,
+            "h5::materialize path is unsupported for this type");
+    }
 }
 #endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -52,6 +52,7 @@ add_test_case(example)
 
 # test content lands in issue/94
 add_test_case(H5compat)
+add_test_case(H5Dgather)
 add_test_case(H5meta)
 add_test_case(H5Tmeta)
 # add_test_case(H5Iall)

--- a/test/H5Dgather.cpp
+++ b/test/H5Dgather.cpp
@@ -1,0 +1,118 @@
+#include <hdf5.h>
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/all>
+#include <h5cpp/H5Dgather.hpp>
+#include <algorithm>
+#include <deque>
+#include <forward_list>
+#include <list>
+#include <set>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+TEST_CASE("H5Dgather gathers list int in iteration order") {
+    std::list<int> values = {1, 2, 3};
+    std::vector<int> elements;
+    const int* ptr = h5::gather(values, elements);
+
+    CHECK(ptr == elements.data());
+    CHECK(elements == std::vector<int>{1, 2, 3});
+}
+
+TEST_CASE("H5Dgather gathers forward list int in iteration order") {
+    std::forward_list<int> values = {1, 2, 3};
+    std::vector<int> elements;
+    const int* ptr = h5::gather(values, elements);
+
+    CHECK(ptr == elements.data());
+    CHECK(elements == std::vector<int>{1, 2, 3});
+}
+
+TEST_CASE("H5Dgather gathers deque int in logical order") {
+    std::deque<int> values = {1, 2, 3};
+    std::vector<int> elements;
+    const int* ptr = h5::gather(values, elements);
+
+    CHECK(ptr == elements.data());
+    CHECK(elements == std::vector<int>{1, 2, 3});
+}
+
+TEST_CASE("H5Dgather gathers set int in sorted order") {
+    std::set<int> values = {3, 1, 2};
+    std::vector<int> elements;
+    const int* ptr = h5::gather(values, elements);
+
+    CHECK(ptr == elements.data());
+    CHECK(elements == std::vector<int>{1, 2, 3});
+}
+
+TEST_CASE("H5Dgather gathers unordered set int without sequence assumption") {
+    std::unordered_set<int> values = {3, 1, 2};
+    std::vector<int> elements;
+    const int* ptr = h5::gather(values, elements);
+    std::set<int> gathered(elements.begin(), elements.end());
+
+    CHECK(ptr == elements.data());
+    CHECK(gathered == std::set<int>{1, 2, 3});
+}
+
+TEST_CASE("H5Dgather materializes list int from flat buffer") {
+    const int values[] = {1, 2, 3};
+    std::list<int> out;
+
+    h5::materialize(out, values, 3);
+
+    CHECK(std::vector<int>(out.begin(), out.end()) == std::vector<int>{1, 2, 3});
+}
+
+TEST_CASE("H5Dgather materializes forward list int from flat buffer") {
+    const int values[] = {1, 2, 3};
+    std::forward_list<int> out;
+
+    h5::materialize(out, values, 3);
+
+    CHECK(std::vector<int>(out.begin(), out.end()) == std::vector<int>{1, 2, 3});
+}
+
+TEST_CASE("H5Dgather materializes deque int from flat buffer") {
+    const int values[] = {1, 2, 3};
+    std::deque<int> out;
+
+    h5::materialize(out, values, 3);
+
+    CHECK(std::vector<int>(out.begin(), out.end()) == std::vector<int>{1, 2, 3});
+}
+
+TEST_CASE("H5Dgather materializes set int from flat buffer") {
+    const int values[] = {3, 1, 2};
+    std::set<int> out;
+
+    h5::materialize(out, values, 3);
+
+    CHECK(out == std::set<int>{1, 2, 3});
+}
+
+TEST_CASE("H5Dgather materializes unordered set int from flat buffer") {
+    const int values[] = {3, 1, 2};
+    std::unordered_set<int> out;
+
+    h5::materialize(out, values, 3);
+
+    CHECK(out == std::unordered_set<int>{1, 2, 3});
+}
+
+TEST_CASE("H5Dgather preserves vector string pointer table gather") {
+    std::vector<std::string> values = {"alpha", "beta", "gamma"};
+    std::vector<const char*> ptrs;
+    const char** table = h5::gather(values, ptrs);
+
+    CHECK(table == ptrs.data());
+    REQUIRE(ptrs.size() == values.size());
+    CHECK(std::string(table[0]) == "alpha");
+    CHECK(std::string(table[1]) == "beta");
+    CHECK(std::string(table[2]) == "gamma");
+    CHECK(table[0] == values[0].data());
+    CHECK(table[1] == values[1].data());
+    CHECK(table[2] == values[2].data());
+}


### PR DESCRIPTION
## Summary
- Add helper-level gather support for non-contiguous linear-value containers.
- Add helper-level materialize support from flat buffers into supported containers.
- Preserve the existing `std::vector<std::string>` pointer-table gather path.
- Replace the old generic gather stdout stub with compile-time unsupported-path diagnostics.
- Add focused doctest coverage in `test/H5Dgather.cpp`.

## Scope
- C++17-compatible helper-level refactor only.
- No dataset read/write/create dispatch changes.
- No datatype synthesis.
- No `H5Ttraits.hpp`.
- No key/value dataset implementation.
- No ragged dataset implementation.
- No fixed-inner-extent dataset implementation.
- No C++23 concepts.

## Test plan
- [x] `cmake -S . -B build -DH5CPP_BUILD_TESTS=ON`
- [x] `cmake --build build --parallel`
- [x] `ctest --test-dir build --output-on-failure`
- [x] `./build/test-h5dgather --reporters=console`