### PR TITLE
[#122]:amelia:modernise namespace and typedef syntax

### DIFF
--- a/h5cpp/H5Eall.hpp
+++ b/h5cpp/H5Eall.hpp
@@ -43,7 +43,7 @@ namespace h5 {
     }
 }
 
-namespace h5 { namespace error {
+namespace h5::error {
 	struct any : public std::runtime_error {
 		any() : std::runtime_error("H5CPP ERROR") {}
 		any(const std::string& msg ) : std::runtime_error( msg ){}
@@ -99,8 +99,8 @@ namespace h5 { namespace error {
 		const std::string get_dataset_type = "???? ...";
 		const std::string create_dcpl = "???? ...";
 	}
-}}
-namespace h5 { namespace error { namespace io {
+}
+namespace h5::error::io {
 	struct rollback : public h5::error::rollback {
 		rollback( const std::string& msg ) : h5::error::rollback( msg ){}
 	};
@@ -108,9 +108,9 @@ namespace h5 { namespace error { namespace io {
 		any() : h5::error::any() {}
 		any( const std::string& msg ) : h5::error::any( msg ){}
 	};
-}}}
+}
 
-namespace h5 { namespace error { namespace io { namespace file {
+namespace h5::error::io::file {
 	struct rollback : public h5::error::io::rollback {
 		rollback( const std::string& msg ) : h5::error::io::rollback( msg ){}
 	};
@@ -142,9 +142,9 @@ namespace h5 { namespace error { namespace io { namespace file {
 		misc() : h5::error::io::file::any() {}
 		misc( const std::string& msg ) : h5::error::io::file::any( msg ){}
 	};
-}}}}
+}
 
-namespace h5 { namespace error { namespace io { namespace dataset {
+namespace h5::error::io::dataset {
 	struct rollback : public h5::error::io::rollback {
 		rollback( const std::string& msg ) : h5::error::io::rollback( msg ){}
 	};
@@ -180,8 +180,8 @@ namespace h5 { namespace error { namespace io { namespace dataset {
 		misc() : h5::error::io::dataset::any() {}
 		misc( const std::string& msg ) : h5::error::io::dataset::any( msg ){}
 	};
-}}}}
-namespace h5 { namespace error { namespace io { namespace packet_table {
+}
+namespace h5::error::io::packet_table {
 	struct rollback : public h5::error::io::rollback {
 		rollback( const std::string& msg ) : h5::error::io::rollback( msg ){}
 	};
@@ -217,9 +217,9 @@ namespace h5 { namespace error { namespace io { namespace packet_table {
 		misc() : h5::error::io::packet_table::any() {}
 		misc( const std::string& msg ) : h5::error::io::packet_table::any( msg ){}
 	};
-}}}}
+}
 
-namespace h5 { namespace error { namespace io { namespace attribute {
+namespace h5::error::io::attribute {
 	struct rollback : public h5::error::io::rollback {
 		rollback( const std::string& msg ) : h5::error::io::rollback( msg ){}
 	};
@@ -251,9 +251,9 @@ namespace h5 { namespace error { namespace io { namespace attribute {
 		misc() : h5::error::io::attribute::any() {}
 		misc( const std::string& msg ) : h5::error::io::attribute::any( msg ){}
 	};
-}}}}
+}
 
-namespace h5 { namespace error { namespace property_list {
+namespace h5::error::property_list {
 	struct rollback : public h5::error::rollback {
 		rollback( const std::string& msg ) : h5::error::rollback( msg ){}
 	};
@@ -269,6 +269,6 @@ namespace h5 { namespace error { namespace property_list {
 		misc() : h5::error::property_list::any() {}
 		misc( const std::string& msg ) : h5::error::property_list::any( msg ){}
 	};
-}}}
+}
 #endif
 

--- a/h5cpp/H5Ialgorithm.hpp
+++ b/h5cpp/H5Ialgorithm.hpp
@@ -9,7 +9,7 @@
 #include <vector>
 #include <stdexcept>
 
-namespace h5 { namespace impl {
+namespace h5::impl {
 	inline static herr_t iterate_callback( ::hid_t gid, const char *name, const H5L_info_t *info, void *op_data){
 		// this must not throw error, CAPI has to clean up
 		try {
@@ -21,7 +21,7 @@ namespace h5 { namespace impl {
 		return 0;
 	}
 
-}}
+}
 
 namespace h5 {
     inline std::vector<std::string> ls(const h5::fd_t& fd,  const std::string& directory ){

--- a/h5cpp/H5Iall.hpp
+++ b/h5cpp/H5Iall.hpp
@@ -16,7 +16,7 @@
 	#define H5CPP__EXPLICIT explicit
 #endif
 
-namespace h5 { namespace impl {
+namespace h5::impl {
 	using capi_close_t = ::herr_t(*)(::hid_t);
 	using defprop_t = ::hid_t(*)();
 
@@ -30,9 +30,9 @@ namespace h5 { namespace impl {
 	};
 	//forward declarations
 	struct at_t;
-}}
+}
 
-namespace h5 { namespace impl { namespace detail {
+namespace h5::impl::detail {
 	/* this mechanism is to alter the behaviour of h5::hid_t through 
 	 * template specialization. The base class is ::any which provides
 	 * conversion policy and resource cleanup
@@ -178,15 +178,15 @@ namespace h5 { namespace impl { namespace detail {
 		std::string name;
 	};
 
-}}}
+}
 
-namespace h5 { namespace impl {
+namespace h5::impl {
 	// redefine ::hid_t<..,from_capi,to_capi,...> to disable conversion, default setting: hid_t::<.., true,true,..>
 	template <class T, capi_close_t capi_call> using aid_t = detail::hid_t<T,capi_call, true,true,detail::hdf5::attribute>;
 	template <class T, capi_close_t capi_call> using hid_t = detail::hid_t<T,capi_call, true,true,detail::hdf5::any>;
 	template <class T, capi_close_t capi_call> using pid_t = detail::hid_t<T,capi_call, true,true,detail::hdf5::property>;
 	template <class T, capi_close_t capi_call> using did_t = detail::hid_t<T,capi_call, true,true,detail::hdf5::dataset>;
-}}
+}
 
 /*hide gory details, and stamp out descriptors */
 namespace h5 {

--- a/h5cpp/H5Marma.hpp
+++ b/h5cpp/H5Marma.hpp
@@ -8,7 +8,7 @@
 //#include "H5Tmeta.hpp"
 
 #if defined(ARMA_INCLUDES) || defined(H5CPP_USE_ARMADILLO)
-namespace h5 { 	namespace arma {
+namespace h5::arma {
 		template<class T> using rowvec = ::arma::Row<T>;
 		template<class T> using colvec = ::arma::Col<T>;
 		template<class T> using colmat = ::arma::Mat<T>;
@@ -18,7 +18,7 @@ namespace h5 { 	namespace arma {
 		template <class Object, class T = typename impl::decay<Object>::type> using is_supported =
 		std::integral_constant<bool, std::is_same<Object,h5::arma::cube<T>>::value || std::is_same<Object,h5::arma::colmat<T>>::value
 			|| std::is_same<Object,h5::arma::rowvec<T>>::value ||  std::is_same<Object,h5::arma::colvec<T>>::value>;
-}}
+}
 
 namespace h5::meta {
     template <class T> struct is_contiguous<h5::arma::rowvec<T>> : std::true_type {};
@@ -28,13 +28,13 @@ namespace h5::meta {
 }
 
 
-namespace h5 { namespace impl {
+namespace h5::impl {
 	// 1.) object -> H5T_xxx
 
-	template <class T> struct decay<h5::arma::rowvec<T>>{ typedef T type; };
-	template <class T> struct decay<h5::arma::colvec<T>>{ typedef T type; };
-	template <class T> struct decay<h5::arma::colmat<T>>{ typedef T type; };
-	template <class T> struct decay<h5::arma::cube<T>>{ typedef T type; };
+	template <class T> struct decay<h5::arma::rowvec<T>>{ using type = T; };
+	template <class T> struct decay<h5::arma::colvec<T>>{ using type = T; };
+	template <class T> struct decay<h5::arma::colmat<T>>{ using type = T; };
+	template <class T> struct decay<h5::arma::cube<T>>{ using type = T; };
 
 	// get read access to datastaore
 	template <class Object, class T = typename impl::decay<Object>::type> inline
@@ -79,6 +79,6 @@ namespace h5 { namespace impl {
 		static inline h5::arma::colmat<T> ctor( std::array<size_t,3> dims ){
 			return h5::arma::colmat<T>( dims[2], dims[0], dims[1] );
 	}};
-}}
+}
 #endif
 #endif

--- a/h5cpp/H5Mblaze.hpp
+++ b/h5cpp/H5Mblaze.hpp
@@ -6,7 +6,7 @@
 #define  H5CPP_BLAZE_HPP
 
 #if defined(_BLAZE_MATH_MODULE_H_) || defined(H5CPP_USE_BLAZE)
-namespace h5 { 	namespace blaze {
+namespace h5::blaze {
 		template<class T> using rowvec = ::blaze::DynamicVector<T,::blaze::rowVector>;
 		template<class T> using colvec = ::blaze::DynamicVector<T,::blaze::columnVector>;
 		template<class T> using rowmat = ::blaze::DynamicMatrix<T,::blaze::rowMajor>;
@@ -16,14 +16,14 @@ namespace h5 { 	namespace blaze {
 		template <class Object, class T = typename impl::decay<Object>::type> using is_supported =
 		std::integral_constant<bool, std::is_same<Object,rowmat<T>>::value || std::is_same<Object,colmat<T>>::value
 			|| std::is_same<Object,rowvec<T>>::value ||  std::is_same<Object,colvec<T>>::value>;
-}}
+}
 
-namespace h5 { namespace impl {
+namespace h5::impl {
 	// 1.) object -> H5T_xxx
-	template <class T> struct decay<h5::blaze::rowvec<T>>{ typedef T type; };
-	template <class T> struct decay<h5::blaze::colvec<T>>{ typedef T type; };
-	template <class T> struct decay<h5::blaze::rowmat<T>>{ typedef T type; };
-	template <class T> struct decay<h5::blaze::colmat<T>>{ typedef T type; };
+	template <class T> struct decay<h5::blaze::rowvec<T>>{ using type = T; };
+	template <class T> struct decay<h5::blaze::colvec<T>>{ using type = T; };
+	template <class T> struct decay<h5::blaze::rowmat<T>>{ using type = T; };
+	template <class T> struct decay<h5::blaze::colmat<T>>{ using type = T; };
 
 	// get read access to datastaore
 	template <class Object, class T = typename impl::decay<Object>::type> inline
@@ -65,7 +65,7 @@ namespace h5 { namespace impl {
 		static inline h5::blaze::colmat<T> ctor( std::array<size_t,2> dims ){
 			return h5::blaze::colmat<T>( dims[0], dims[1] );
 	}};
-}}
+}
 
 #endif
 #endif

--- a/h5cpp/H5Mdlib.hpp
+++ b/h5cpp/H5Mdlib.hpp
@@ -6,7 +6,7 @@
 #define  H5CPP_DLIB_HPP
 
 #if defined(DLIB_MATRIx_HEADER) || defined(H5CPP_USE_DLIB)
-namespace h5 { 	namespace dlib {
+namespace h5::dlib {
 // dlib template:
 // const dlib::matrix<short int, 0, 0, dlib::memory_manager_stateless_kernel_1<char>, dlib::row_major_layout>&
 		template<class T> using rowmat = ::dlib::matrix<T, 0, 0,
@@ -14,10 +14,10 @@ namespace h5 { 	namespace dlib {
 			::dlib::row_major_layout>;
 		template <class Object, class T = typename impl::decay<Object>::type>
 			using is_supported = std::integral_constant<bool, std::is_same<Object,h5::dlib::rowmat<T>>::value>;
-}}
-namespace h5 { namespace impl {
+}
+namespace h5::impl {
 	// 1.) object -> H5T_xxx
-	template <class T> struct decay<h5::dlib::rowmat<T>>{ typedef T type; };
+	template <class T> struct decay<h5::dlib::rowmat<T>>{ using type = T; };
 
 	// get read access to datastaore
 	template <class Object, class T = typename impl::decay<Object>::type> inline
@@ -46,6 +46,6 @@ namespace h5 { namespace impl {
 		static inline h5::dlib::rowmat<T> ctor( std::array<size_t,2> dims ){
 			return h5::dlib::rowmat<T>( dims[1], dims[0] );
 	}};
-}}
+}
 #endif
 #endif

--- a/h5cpp/H5Meigen.hpp
+++ b/h5cpp/H5Meigen.hpp
@@ -26,10 +26,10 @@ namespace h5::meta {
     template<class T,int R,int C, int O> struct is_contiguous<::Eigen::Array<T,R,C,O>> : std::true_type {};
 }
 
-namespace h5 { namespace impl {
+namespace h5::impl {
 	// 1.) object -> H5T_xxx
-	template<class T,int R,int C, int O> struct decay<::Eigen::Matrix<T,R,C,O>>{ typedef T type; };
-	template<class T,int R,int C, int O> struct decay<::Eigen::Array<T,R,C,O>>{ typedef T type; };
+	template<class T,int R,int C, int O> struct decay<::Eigen::Matrix<T,R,C,O>>{ using type = T; };
+	template<class T,int R,int C, int O> struct decay<::Eigen::Array<T,R,C,O>>{ using type = T; };
 	    
 
 	// TODO: remove const_cast
@@ -118,7 +118,7 @@ namespace h5 { namespace impl {
 		static inline ::Eigen::Array<T,R,C,::Eigen::ColMajor,MR,MC> ctor( std::array<size_t,2> dims ){
 			return ::Eigen::Array<T,R,C,::Eigen::ColMajor,MR,MC>( dims[1], dims[0] );
 	}};
-}}
+}
 
 #endif
 #endif

--- a/h5cpp/H5Mitpp.hpp
+++ b/h5cpp/H5Mitpp.hpp
@@ -7,14 +7,14 @@
 
 
 #if defined(MAT_H) || defined(H5CPP_USE_ITPP_MATRIX)
-namespace h5 { 	namespace itpp {
+namespace h5::itpp {
 		template<class T> using rowmat = ::itpp::Mat<T>;
 		template <class Object, class T = typename impl::decay<Object>::type> 
 			using is_supported = std::integral_constant<bool, std::is_same<Object,h5::itpp::rowmat<T>>::value>;
-}}
-namespace h5 { namespace impl {
+}
+namespace h5::impl {
 	// 1.) object -> H5T_xxx
-	template <class T> struct decay<h5::itpp::rowmat<T>>{ typedef T type; };
+	template <class T> struct decay<h5::itpp::rowmat<T>>{ using type = T; };
 
 	// get read access to datastaore
 	template <class Object, class T = typename impl::decay<Object>::type> inline
@@ -34,17 +34,17 @@ namespace h5 { namespace impl {
 		static inline h5::itpp::rowmat<T> ctor( std::array<size_t,2> dims ){
 			return h5::itpp::rowmat<T>( dims[1], dims[0] );
 	}};
-}}
+}
 #endif
 
 #if defined(VEC_H) || defined(H5CPP_USE_ITPP_VECTOR)
-namespace h5 { 	namespace itpp {
+namespace h5::itpp {
 		template<class T> using rowvec = ::itpp::Vec<T>;
 		template <class Object, class T = typename impl::decay<Object>::type>
 			using is_supported_v = std::integral_constant<bool, std::is_same<Object,h5::itpp::rowvec<T>>::value>;
-}}
-namespace h5 { namespace impl {
-	template <class T> struct decay<h5::itpp::rowvec<T>>{ typedef T type; };
+}
+namespace h5::impl {
+	template <class T> struct decay<h5::itpp::rowvec<T>>{ using type = T; };
 	template <class Object, class T = typename impl::decay<Object>::type> inline
 	typename std::enable_if< h5::itpp::is_supported_v<Object>::value,
 	const T*>::type data(const Object& ref ){
@@ -61,6 +61,6 @@ namespace h5 { namespace impl {
 		static inline h5::itpp::rowvec<T> ctor( std::array<size_t,1> dims ){
 			return h5::itpp::rowvec<T>( dims[0] );
 	}};
-}}
+}
 #endif
 #endif

--- a/h5cpp/H5Mstl.hpp
+++ b/h5cpp/H5Mstl.hpp
@@ -11,7 +11,7 @@
 #include <initializer_list>
 #include <type_traits>
 
-namespace h5 { namespace impl {
+namespace h5::impl {
 /*STL: */
 	// 2.) filter is_xxx_type
 	// 4.) write access
@@ -19,21 +19,21 @@ namespace h5 { namespace impl {
 	// 6.) ctor with right dimensions
 
 	// 1.) object -> H5T_xxx
-	template <class T, class...> struct decay{ typedef T type; };
+	template <class T, class...> struct decay{ using type = T; };
 
-	template <class T> struct decay<const T>{ typedef T type; };
-	template <class T> struct decay<const T*>{ typedef T* type; };
-	template <class T> struct decay<std::basic_string<T>>{ typedef const T* type; };
-	template <class T, signed N> struct decay<const T[N]>{ typedef T* type; };
-	template <class T, signed N> struct decay<T[N]>{ typedef T* type; };
+	template <class T> struct decay<const T>{ using type = T; };
+	template <class T> struct decay<const T*>{ using type = T*; };
+	template <class T> struct decay<std::basic_string<T>>{ using type = const T*; };
+	template <class T, signed N> struct decay<const T[N]>{ using type = T*; };
+	template <class T, signed N> struct decay<T[N]>{ using type = T*; };
 
-	template <class T> struct decay<std::initializer_list<const T*>>{ typedef const T* type; };
-	template <class T> struct decay<std::initializer_list<T*>>{ typedef T* type; };
-	template <class T> struct decay<std::initializer_list<T>>{ typedef T type; };
+	template <class T> struct decay<std::initializer_list<const T*>>{ using type = const T*; };
+	template <class T> struct decay<std::initializer_list<T*>>{ using type = T*; };
+	template <class T> struct decay<std::initializer_list<T>>{ using type = T; };
 
-	template <class T> struct decay<std::vector<const T*>>{ typedef const T* type; };
-	template <class T> struct decay<std::vector<T*>>{ typedef T* type; };
-	template <class T> struct decay<std::vector<T>>{ typedef T type; };
+	template <class T> struct decay<std::vector<const T*>>{ using type = const T*; };
+	template <class T> struct decay<std::vector<T*>>{ using type = T*; };
+	template <class T> struct decay<std::vector<T>>{ using type = T; };
 
 	// helpers
 	template <class T>
@@ -84,5 +84,5 @@ namespace h5 { namespace impl {
 		static inline std::vector<T> ctor( std::array<size_t,1> dims ){
 			return std::vector<T>( dims[0] );
 	}};
-}}
+}
 #endif

--- a/h5cpp/H5Mublas.hpp
+++ b/h5cpp/H5Mublas.hpp
@@ -6,14 +6,14 @@
 #define  H5CPP_UBLAS_HPP
 
 #if defined(_BOOST_UBLAS_MATRIX_) || defined(H5CPP_USE_UBLAS_MATRIX)
-namespace h5 { 	namespace ublas {
+namespace h5::ublas {
 		template<class T> using rowmat 	= ::boost::numeric::ublas::matrix<T>;
 		template <class Object, class T = typename impl::decay<Object>::type> 
 			using is_supportedm = std::integral_constant<bool, std::is_same<Object,h5::ublas::rowmat<T>>::value>;
-}}
-namespace h5 { namespace impl {
+}
+namespace h5::impl {
 	// 1.) object -> H5T_xxx
-	template <class T> struct decay<h5::ublas::rowmat<T>>{ typedef T type; };
+	template <class T> struct decay<h5::ublas::rowmat<T>>{ using type = T; };
 	// get read access to datastaore
 	template <class Object, class T = typename impl::decay<Object>::type> inline
 	typename std::enable_if< h5::ublas::is_supportedm<Object>::value,
@@ -32,17 +32,17 @@ namespace h5 { namespace impl {
 		static inline h5::ublas::rowmat<T> ctor( std::array<size_t,2> dims ){
 			return h5::ublas::rowmat<T>( dims[1], dims[0] );
 	}};
-}}
+}
 #endif
 
 #if defined(_BOOST_UBLAS_VECTOR_) || defined(H5CPP_USE_UBLAS_VECTOR)
-namespace h5 { 	namespace ublas {
+namespace h5::ublas {
 		template<class T> using rowvec = ::boost::numeric::ublas::vector<T>;
 		template <class Object, class T = typename impl::decay<Object>::type>
 			using is_supportedv = std::integral_constant<bool, std::is_same<Object,h5::ublas::rowvec<T>>::value>;
-}}
-namespace h5 { namespace impl {
-	template <class T> struct decay<h5::ublas::rowvec<T>>{ typedef T type; };
+}
+namespace h5::impl {
+	template <class T> struct decay<h5::ublas::rowvec<T>>{ using type = T; };
 	template <class Object, class T = typename impl::decay<Object>::type> inline
 	typename std::enable_if< h5::ublas::is_supportedv<Object>::value,
 	const T*>::type data(const Object& ref ){
@@ -59,6 +59,6 @@ namespace h5 { namespace impl {
 		static inline h5::ublas::rowvec<T> ctor( std::array<size_t,1> dims ){
 			return h5::ublas::rowvec<T>( dims[0] );
 	}};
-}}
+}
 #endif
 #endif

--- a/h5cpp/H5Pall.hpp
+++ b/h5cpp/H5Pall.hpp
@@ -11,7 +11,7 @@
 #include <algorithm>
 #include <iterator>
 
-namespace h5 { namespace impl {
+namespace h5::impl {
 	/* proxy object that gets converted to property_id with restriction that 
 	 * only same class properties may be daisy chained */
 	template <class Derived, class phid_t>
@@ -139,7 +139,7 @@ namespace h5 { namespace impl {
 	// only data control property list set_value has this pattern, lets allow to define CAPI argument lists 
 	// the same way as with others
 	template <class capi, typename capi::fn_t capi_call, class T> using dcpl_tcall = tprop_t<h5::dcpl_t,default_dcpl, capi, capi_call, T>;
-}}
+}
 
 namespace h5::impl {
 	template <bool version, class capi, typename capi::fn_t capi_call  > 
@@ -375,7 +375,7 @@ const static h5::dxpl_mpiio_collective_opt individual_io{H5FD_MPIO_INDIVIDUAL_IO
 #endif
 }
 
-namespace h5 { namespace notimplemented_yet { // OBJECT COPY PROPERTY LISTS
+namespace h5::notimplemented_yet { // OBJECT COPY PROPERTY LISTS
 	//using char_encoding_ =              = impl::fapl_call< impl::fapl_args<hid_t, >,H5Pset_char_encoding, H5T_cset_t)
 	//static h5::char_encoding_ ascii{H5T_CSET_ASCII};
 	//static h5::char_encoding_ utf8{H5T_CSET_UTF8};
@@ -385,7 +385,7 @@ namespace h5 { namespace notimplemented_yet { // OBJECT COPY PROPERTY LISTS
 	//NOT MAPPED: fapl_direct, mpiposix, fapl_multi
 	//MISSING:	H5CPP__PROPERTYLIST_FLAG(fapl, fapl_windows)
 	//MISSING:	using file_image_callbacks, H5_file_image_callbacks_t* >;
-}}
+}
 
 
 namespace h5 {

--- a/h5cpp/H5Pdapl.hpp
+++ b/h5cpp/H5Pdapl.hpp
@@ -7,7 +7,7 @@
 
 #define H5CPP_DAPL_HIGH_THROUGHPUT "h5cpp_dapl_highthroughput"
 
-namespace h5 { namespace impl {
+namespace h5::impl {
 	inline herr_t dapl_pipeline_close( const char *name, size_t size, void *ptr ){
 		delete *static_cast< impl::pipeline_t<impl::basic_pipeline_t>**>( ptr );
 		return 0;
@@ -25,7 +25,7 @@ namespace h5 { namespace impl {
 			return 0;
 #endif
 	}
-}}
+}
 
 namespace h5 {
 // DATA ACCESS PROPERTY LISTS

--- a/h5cpp/H5Tall.hpp
+++ b/h5cpp/H5Tall.hpp
@@ -50,7 +50,7 @@ namespace h5::impl::detail {
  */
 
 #define H5CPP_REGISTER_TYPE_( C_TYPE, H5_TYPE )                                           \
-namespace h5 { namespace impl { namespace detail { 	                                      \
+namespace h5::impl::detail { 	                                      \
 	template <> struct hid_t<C_TYPE,H5Tclose,true,true,hdf5::type> : public dt_p<C_TYPE> {\
 		using parent = dt_p<C_TYPE>;                                                      \
 		using dt_p<C_TYPE>::hid_t;                                                              \
@@ -61,7 +61,7 @@ namespace h5 { namespace impl { namespace detail { 	                            
 					H5Tset_size (id,H5T_VARIABLE), H5Tset_cset(id, H5T_CSET_UTF8);        \
 		}                                                                                 \
 	};                                                                                    \
-}}}                                                                                       \
+}                                                                                         \
 namespace h5 {                                                                            \
 	template <> struct name<C_TYPE> {                                                     \
 		static constexpr char const * value = #C_TYPE;                                    \

--- a/h5cpp/H5Zall.hpp
+++ b/h5cpp/H5Zall.hpp
@@ -11,7 +11,7 @@
 #include <zlib.h>
 #include <cmath>
 
-namespace h5 { namespace impl { namespace filter {
+namespace h5::impl::filter {
 	// TODO: figure something out to map c++ filters to C calls? 
 	template<class Derived>
 	struct filter_t {
@@ -100,5 +100,5 @@ namespace h5 { namespace impl { namespace filter {
 	}
 
 
-}}}
+}
 #endif

--- a/h5cpp/H5capi.hpp
+++ b/h5cpp/H5capi.hpp
@@ -10,23 +10,6 @@
 #include <memory>
 #include <cstdlib>
 
-/* rules:
- * h5::id_t{ hid_t } or direct initialization  doesn't increment reference count
- */ 
-namespace h5::impl {
-	struct free {
-		template <typename T>
-		void operator()(T *p) const {
-			using T_ = typename std::remove_const<T>::type;
-			std::free( const_cast<T_*>(p) );
-		}
-	};
-
-	template <typename T>
-		using unique_ptr = std::unique_ptr<T,h5::impl::free>;
-}
-
-
 namespace h5 {
 	inline ::hid_t get_access_plist( const ds_t& ds ){
 		return ds.dapl;

--- a/h5cpp/H5capi.hpp
+++ b/h5cpp/H5capi.hpp
@@ -12,7 +12,21 @@
 
 /* rules:
  * h5::id_t{ hid_t } or direct initialization  doesn't increment reference count
- */
+ */ 
+namespace h5::impl {
+	struct free {
+		template <typename T>
+		void operator()(T *p) const {
+			using T_ = typename std::remove_const<T>::type;
+			std::free( const_cast<T_*>(p) );
+		}
+	};
+
+	template <typename T>
+		using unique_ptr = std::unique_ptr<T,h5::impl::free>;
+}
+
+
 namespace h5 {
 	inline ::hid_t get_access_plist( const ds_t& ds ){
 		return ds.dapl;

--- a/h5cpp/H5misc.hpp
+++ b/h5cpp/H5misc.hpp
@@ -100,7 +100,7 @@ namespace h5::utils {
 
 }
 
-namespace h5 { namespace impl {
+namespace h5::impl {
     struct free {
         template <typename T>
         void operator()(T *p) const {
@@ -110,6 +110,6 @@ namespace h5 { namespace impl {
     };
     template <typename T>
         using unique_ptr = std::unique_ptr<T, h5::impl::free>;
-}}
+}
 #endif
 


### PR DESCRIPTION
## Summary

- Replace all `namespace h5 { namespace X {` nested opens with C++17 compact `namespace h5::X {` form across 14 headers (including 2-deep, 3-deep, and 4-deep nesting in H5Eall, H5Iall, H5Zall)
- Convert all `typedef T type;` member aliases in metafunction structs (`decay<>`, etc.) to `using type = T;`

Closes #122

## Test plan

- [ ] Project builds without error with same compiler flags as CI
- [ ] No functional change: all symbols, ABI, and semantics identical to before
- [ ] `grep -r "namespace h5 { namespace"` returns no hits in h5cpp/
- [ ] `grep -r "typedef.*type;"` returns no hits in the 14 modified headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)