### PR TITLE
[#127]:amelia:docs, add build matrix badges, update h5cpp-compiler LLVM version

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,21 @@
  Author: Varga, Steven <steven@vargaconsulting.ca>
 --->
 
+[![CI](https://github.com/vargalabs/h5cpp/actions/workflows/ci.yml/badge.svg)](https://github.com/vargalabs/h5cpp/actions/workflows/ci.yml)
+[![MIT License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
+[![GitHub release](https://img.shields.io/github/v/release/vargalabs/h5cpp.svg)](https://github.com/vargalabs/h5cpp/releases)
+[![Documentation](https://img.shields.io/badge/docs-stable-blue)](https://vargalabs.github.io/h5cpp)
+
 Easy to use  [HDF5][hdf5] C++ templates for Serial and Paralell HDF5  
 ----------------------------------------------------------------------
+
+## Build Matrix
+
+| OS / Compiler | GCC 13       | GCC 14       | GCC 15       | Clang 17       | Clang 18       | Clang 19       | Clang 20       |
+|---------------|--------------|--------------|--------------|----------------|----------------|----------------|----------------|
+| Ubuntu 22.04  |![gcc13][200] |![gcc14][201] |![gcc15][202] |![clang17][250] |![clang18][251] |![clang19][252] |![clang20][253] |
+| Ubuntu 24.04  |![gcc13][300] |![gcc14][301] |![gcc15][302] |![clang17][350] |![clang18][351] |![clang19][352] |![clang20][353] |
+
 **News:**
 **optional custom dataype** is added to `h5::create` to allow custom dataypes passed along the other arguments. 
 ```cpp
@@ -31,14 +44,12 @@ H5Dwrite( ds[idx], hdf5_data_type, mem_space, file_space, H5P_DEFAULT, data.data
 
 
 
-
-h5cpp compiler can easily be compiled with stock LLVM6.0 and clang6.0 
-binary release h5cpp-dev_1.10.4-5.xxx contains bug fixes, and half float support, [deb](http://h5cpp.org/download/h5cpp-dev_1.10.4-5_amd64.deb),[rpm](http://h5cpp.org/download/h5cpp-dev-1.10.4-5.x86_64.rpm),[tarball](http://h5cpp.org/download/h5cpp-full_1.10.4-5.tar.gz)
+The [h5cpp source transformation tool](https://github.com/vargalabs/h5cpp-compiler) requires Clang/LLVM 14, 15, or 17.
 
 
 [Hierarchical Data Format][hdf5] prevalent in high performance scientific computing, sits directly on top of sequential or parallel file systems, providing block and stream operations on standardized or custom binary/text objects. Scientific computing platforms such as Python, R, Matlab, Fortran,  Julia [and many more...] come with the necessary libraries to read write HDF5 dataset. This edition simplifies interactions with [popular linear algebra libraries][304], provides [compiler assisted seamless object persistence][303], Standard Template Library support and equipped with novel [error handling architecture][400].
 
-H5CPP is a novel approach to  persistence in the field of machine learning, it provides high performance sequential and block access to HDF5 containers through modern C++ [Download packages from here.](http://h5cpp.org/download) If you are interested in h5cpp LLVM/clang based source code transformation tool [you find it in this separate project.](https://github.com/steven-varga/h5cpp-compiler)
+H5CPP is a novel approach to  persistence in the field of machine learning, it provides high performance sequential and block access to HDF5 containers through modern C++ [Download packages from here.](http://h5cpp.org/download) If you are interested in h5cpp LLVM/clang based source code transformation tool [you find it in this separate project.](https://github.com/vargalabs/h5cpp-compiler)
 
 You can read this [blog post][500] published on HDFGroup Blog site to find out where the project is originated. [Click here Doxygen based Documentation][501] pages. Browse [highlighted examples][502], follow this link to [our spring presentation](http://webinar.h5cpp.org) or take a peek at the upcoming [ISC'19 BOF](http://isc19.hdf5.io), where I am [presenting H5CPP](https://forum.hdfgroup.org/t/hdf5-bof-at-isc-19/5692).
 
@@ -100,8 +111,8 @@ template <typename T> h5::err_t write( dataset,  const T& ref
 template <typename T> void h5::append(h5::pt_t& ds, const T& ref) [noexcept];
 ```
 
-All **file and dataset io** descriptors implement [raii idiom][301] and close underlying resource when going out of scope, 
-and may be seamlessly passed to HDF5 CAPI calls when implicit conversion enabled. Similarly templates can take CAPI `hid_t` identifiers as arguments where applicable provided conversion policy allows. See [conversion policy][301] for details.
+All **file and dataset io** descriptors implement [raii idiom][601] and close underlying resource when going out of scope, 
+and may be seamlessly passed to HDF5 CAPI calls when implicit conversion enabled. Similarly templates can take CAPI `hid_t` identifiers as arguments where applicable provided conversion policy allows. See [conversion policy][601] for details.
 
 install:
 -----------
@@ -211,22 +222,33 @@ while( having_a_good_day ){
 [105]: http://dlib.net/linear_algebra.html
 [106]: https://bitbucket.org/blaze-lib/blaze
 [107]: https://github.com/wichtounet/etl
-[200]: http://h5cpp.org/md__home_steven_Documents_projects_h5cpp_profiling_README.html
-[201]: http://h5cpp.org/examples.html
-[202]: http://h5cpp.org/modules.html
-[305]: md__home_steven_Documents_projects_h5cpp_docs_pages_compiler_trial.html#link_try_compiler
-[400]: https://www.meetup.com/Chicago-C-CPP-Users-Group/events/250655716/
-[401]: https://www.hdfgroup.org/2018/07/cpp-has-come-a-long-way-and-theres-plenty-in-it-for-users-of-hdf5/
-[999]: http://h5cpp.org/cgi/redirect.py
-[301]: http://h5cpp.org/md__home_steven_Documents_projects_h5cpp_docs_pages_conversion.html
-[302]: http://h5cpp.org/md__home_steven_Documents_projects_h5cpp_docs_pages_exceptions.html
 [303]: http://h5cpp.org/md__home_steven_Documents_projects_h5cpp_docs_pages_compiler.html
 [304]: http://h5cpp.org/md__home_steven_Documents_projects_h5cpp_docs_pages_linalg.html
 [305]: http://h5cpp.org/md__home_steven_Documents_projects_h5cpp_docs_pages_install.html
 [400]: http://h5cpp.org/md__home_steven_Documents_projects_h5cpp_docs_pages_error_handling.html
+[401]: https://www.hdfgroup.org/2018/07/cpp-has-come-a-long-way-and-theres-plenty-in-it-for-users-of-hdf5/
 [500]: http://h5cpp.org/md__home_steven_Documents_projects_h5cpp_docs_pages_blog.html
 [501]: http://h5cpp.org/modules.html
 [502]: http://h5cpp.org/examples.html
 [503]: http://h5cpp.org/independent_8cpp-example.html
 [504]: http://h5cpp.org/collective_8cpp-example.html
 [505]: http://h5cpp.org/throughput_8cpp-example.html
+[601]: http://h5cpp.org/md__home_steven_Documents_projects_h5cpp_docs_pages_conversion.html
+
+<!-- Ubuntu 22.04 -->
+[200]: https://vargalabs.github.io/h5cpp/badges/ubuntu-22.04-gcc-13.svg
+[201]: https://vargalabs.github.io/h5cpp/badges/ubuntu-22.04-gcc-14.svg
+[202]: https://vargalabs.github.io/h5cpp/badges/ubuntu-22.04-gcc-15.svg
+[250]: https://vargalabs.github.io/h5cpp/badges/ubuntu-22.04-clang-17.svg
+[251]: https://vargalabs.github.io/h5cpp/badges/ubuntu-22.04-clang-18.svg
+[252]: https://vargalabs.github.io/h5cpp/badges/ubuntu-22.04-clang-19.svg
+[253]: https://vargalabs.github.io/h5cpp/badges/ubuntu-22.04-clang-20.svg
+
+<!-- Ubuntu 24.04 -->
+[300]: https://vargalabs.github.io/h5cpp/badges/ubuntu-24.04-gcc-13.svg
+[301]: https://vargalabs.github.io/h5cpp/badges/ubuntu-24.04-gcc-14.svg
+[302]: https://vargalabs.github.io/h5cpp/badges/ubuntu-24.04-gcc-15.svg
+[350]: https://vargalabs.github.io/h5cpp/badges/ubuntu-24.04-clang-17.svg
+[351]: https://vargalabs.github.io/h5cpp/badges/ubuntu-24.04-clang-18.svg
+[352]: https://vargalabs.github.io/h5cpp/badges/ubuntu-24.04-clang-19.svg
+[353]: https://vargalabs.github.io/h5cpp/badges/ubuntu-24.04-clang-20.svg


### PR DESCRIPTION
## Summary

- Add shields.io badge strip (CI, license, release, docs) at top of README
- Add `## Build Matrix` table (Ubuntu 22.04 + 24.04 × GCC 13/14/15 + Clang 17/18/19/20) using numbered image-reference pattern consistent with iex2h5 and h5cpp-compiler
- Update stale `LLVM6.0 / clang6.0` compiler reference — h5cpp-compiler currently supports Clang/LLVM 14, 15, and 17
- Fix link-reference collisions: `[301]` (raii/conversion-policy) renamed to `[601]`; stale `[200]/[201]/[202]/[302]` Doxygen refs replaced by badge SVG URLs; duplicate `[305]/[400]` definitions deduplicated

The CI badge-generation machinery (`ci.yml` `generate-badges` job + `peaceiris/actions-gh-pages` publish to `vargalabs.github.io/h5cpp/badges/`) was already in place — only the README was missing.

## Test plan

- [ ] Verify badge strip renders correctly on GitHub after merge
- [ ] Confirm `generate-badges` CI job publishes SVGs to `gh-pages` on next push to `staging`/`release`
- [ ] Spot-check that `[601]` raii/conversion-policy links resolve correctly in rendered README

Closes #127

🤖 Generated with [Claude Code](https://claude.ai/claude-code)