### PR TITLE
[#131] Cleanup codebase: pragma once migration and h5::adelete implementation

### DIFF
--- a/h5cpp/H5Acreate.hpp
+++ b/h5cpp/H5Acreate.hpp
@@ -2,8 +2,7 @@
  * Copyright (c) 2018-2020 Steven Varga, Toronto,ON Canada
  * Author: Varga, Steven <steven@vargaconsulting.ca>
  */
-#ifndef  H5CPP_ACREATE_HPP
-#define  H5CPP_ACREATE_HPP
+#pragma once
 #include <string>
 #include <stdexcept>
 #include <type_traits>
@@ -44,7 +43,4 @@ namespace h5 {
 				throw h5::error::io::attribute::create( err.what() );
 		}
 	}
-
 }
-#endif
-

--- a/h5cpp/H5Adelete.hpp
+++ b/h5cpp/H5Adelete.hpp
@@ -2,8 +2,20 @@
  * Copyright (c) 2018-2020 Steven Varga, Toronto,ON Canada
  * Author: Varga, Steven <steven@vargaconsulting.ca>
  */
-#ifndef  H5CPP_ADELETE_HPP
-#define  H5CPP_ADELETE_HPP
+#pragma once
 
-#endif
+#include <string>
+#include <type_traits>
+
+namespace h5 {
+    // Delete an attribute from an HDF5 object by name
+    template<class HID_T>
+    inline std::enable_if_t<h5::impl::is_valid_attr<HID_T>::value, void>
+    adelete(const HID_T& parent, const std::string& name) {
+        H5CPP_CHECK_NZ(
+            H5Adelete(static_cast<hid_t>(parent), name.c_str()),
+            h5::error::io::attribute::delete_,
+            "couldn't delete attribute");
+    }
+}
 

--- a/h5cpp/H5Aopen.hpp
+++ b/h5cpp/H5Aopen.hpp
@@ -2,8 +2,7 @@
  * Copyright (c) 2018-2020 Steven Varga, Toronto,ON Canada
  * Author: Varga, Steven <steven@vargaconsulting.ca>
  */
-#ifndef  H5CPP_AOPEN_HPP
-#define  H5CPP_AOPEN_HPP
+#pragma once
 #include <string>
 #include <type_traits>
 namespace h5 {
@@ -19,5 +18,3 @@ namespace h5 {
      	return  h5::at_t{attr};
     }
 }
-#endif
-

--- a/h5cpp/H5Aread.hpp
+++ b/h5cpp/H5Aread.hpp
@@ -2,8 +2,7 @@
  * Copyright (c) 2018-2020 Steven Varga, Toronto,ON Canada
  * Author: Varga, Steven <steven@vargaconsulting.ca>
  */
-#ifndef  H5CPP_AREAD_HPP
-#define  H5CPP_AREAD_HPP
+#pragma once
 #include <string>
 #include <type_traits>
 namespace h5 {
@@ -84,7 +83,4 @@ namespace h5 {
         }
 		return object;
 	}
-
 }
-#endif
-

--- a/h5cpp/H5Awrite.hpp
+++ b/h5cpp/H5Awrite.hpp
@@ -3,8 +3,7 @@
  * Author: Varga, Steven <steven@vargaconsulting.ca>
  */
 
-#ifndef  H5CPP_AWRITE_HPP
-#define  H5CPP_AWRITE_HPP
+#pragma once
 #include <string>
 #include <stdexcept>
 #include <type_traits>
@@ -95,6 +94,4 @@ h5::at_t h5::at_t::operator=( const std::initializer_list<V> args ){
 	h5::awrite(ds, name, args);
 	return *this;
 }
-
-#endif
 

--- a/h5cpp/H5Dappend.hpp
+++ b/h5cpp/H5Dappend.hpp
@@ -3,8 +3,7 @@
  * Author: Varga, Steven <steven@vargaconsulting.ca>
  */
 
-#ifndef H5CPP_DAPPEND_HPP
-#define H5CPP_DAPPEND_HPP
+#pragma once
 #include <zlib.h>
 #include <string>
 #include <vector>
@@ -313,4 +312,3 @@ inline std::ostream& operator<<(std::ostream &os, const h5::pt_t& pt) {
     os << std::dec;
 	return os;
 }
-#endif

--- a/h5cpp/H5Dcreate.hpp
+++ b/h5cpp/H5Dcreate.hpp
@@ -2,8 +2,7 @@
  * Copyright (c) 2018-2021 Steven Varga, Toronto,ON Canada
  * Author: Varga, Steven <steven@vargaconsulting.ca>
  */
-#ifndef  H5CPP_DCREATE_HPP
-#define  H5CPP_DCREATE_HPP
+#pragma once
 #include <string>
 #include <stdexcept>
 #include <tuple>
@@ -139,5 +138,3 @@ namespace h5 {
 		return h5::create<T>(fd, dataset_path, args...);
 	}
 }
-#endif
-

--- a/h5cpp/H5Dgather.hpp
+++ b/h5cpp/H5Dgather.hpp
@@ -2,8 +2,7 @@
  * Copyright (c) 2018 - 2021 vargaconsulting, Toronto,ON Canada
  * Author: Varga, Steven <steven@vargaconsulting.ca>
  */
-#ifndef  H5CPP_DGATHER_HPP 
-#define  H5CPP_DGATHER_HPP
+#pragma once
 
 #include <cstddef>
 #include <vector>
@@ -137,4 +136,3 @@ namespace h5 {
             "h5::materialize path is unsupported for this type");
     }
 }
-#endif

--- a/h5cpp/H5Dopen.hpp
+++ b/h5cpp/H5Dopen.hpp
@@ -3,8 +3,7 @@
  * Author: Varga, Steven <steven@vargaconsulting.ca>
  */
 
-#ifndef  H5CPP_DOPEN_HPP
-#define  H5CPP_DOPEN_HPP
+#pragma once
 #include <string>
 
 namespace h5{
@@ -58,6 +57,4 @@ namespace h5{
 		return ds_;
     }
 }
-
-#endif
 

--- a/h5cpp/H5Dread.hpp
+++ b/h5cpp/H5Dread.hpp
@@ -3,8 +3,7 @@
  * Author: Varga, Steven <steven@vargaconsulting.ca>
  */
 
-#ifndef  H5CPP_DREAD_HPP
-#define  H5CPP_DREAD_HPP
+#pragma once
 #include "H5Dopen.hpp" // be sure this precedes error handling macro-s !!!
 #include <string>
 #include <vector>
@@ -322,4 +321,3 @@ namespace h5 {
 		return h5::read<T>( fd, dataset_path, args...);
 	}
 }
-#endif

--- a/h5cpp/H5Dscatter.hpp
+++ b/h5cpp/H5Dscatter.hpp
@@ -2,6 +2,4 @@
  * Copyright (c) 2018 - 2021 vargaconsulting, Toronto,ON Canada
  * Author: Varga, Steven <steven@vargaconsulting.ca>
  */
-#ifndef  H5CPP_DSCATTER_HPP 
-#define  H5CPP_DSCATTER_HPP
-#endif
+#pragma once

--- a/h5cpp/H5Dwrite.hpp
+++ b/h5cpp/H5Dwrite.hpp
@@ -1,10 +1,8 @@
-        /*
+/*
  * Copyright (c) 2018 - 2021 vargaconsulting, Toronto,ON Canada
  * Author: Varga, Steven <steven@vargaconsulting.ca>
  */
-
-#ifndef H5CPP_DWRITE_HPP
-#define H5CPP_DWRITE_HPP
+#pragma once
 
 #include "H5Tmeta.hpp"
 #include "H5Dgather.hpp"
@@ -417,4 +415,3 @@ namespace h5 {
 		return h5::write( fd, dataset_path, args...);
 	}
 }
-#endif

--- a/h5cpp/H5Eall.hpp
+++ b/h5cpp/H5Eall.hpp
@@ -250,6 +250,10 @@ namespace h5::error::io::attribute {
 		misc() : h5::error::io::attribute::any() {}
 		misc( const std::string& msg ) : h5::error::io::attribute::any( msg ){}
 	};
+	struct delete_ : public h5::error::io::attribute::any {
+		delete_() : h5::error::io::attribute::any() {}
+		delete_( const std::string& msg ) : h5::error::io::attribute::any( msg ){}
+	};
 }
 
 namespace h5::error::property_list {

--- a/h5cpp/H5Eall.hpp
+++ b/h5cpp/H5Eall.hpp
@@ -2,8 +2,7 @@
  * Copyright (c) 2018-2020 Steven Varga, Toronto,ON Canada
  * Author: Varga, Steven <steven@vargaconsulting.ca>
  */
-#ifndef  H5CPP_EALL_HPP
-#define  H5CPP_EALL_HPP
+#pragma once
 #include <stdexcept>
 #include <string>
 #include <iostream>
@@ -270,5 +269,3 @@ namespace h5::error::property_list {
 		misc( const std::string& msg ) : h5::error::property_list::any( msg ){}
 	};
 }
-#endif
-

--- a/h5cpp/H5Fcreate.hpp
+++ b/h5cpp/H5Fcreate.hpp
@@ -3,8 +3,7 @@
  * Author: Varga, Steven <steven@vargaconsulting.ca>
  */
 
-#ifndef  H5CPP_FCREATE_HPP
-#define  H5CPP_FCREATE_HPP
+#pragma once
 #include <string>
 
 /**
@@ -59,5 +58,3 @@ namespace h5{
         return fd_t{fd};
     }
 }
-#endif
-

--- a/h5cpp/H5Fopen.hpp
+++ b/h5cpp/H5Fopen.hpp
@@ -2,8 +2,7 @@
  * Copyright (c) 2018-2020 Steven Varga, Toronto,ON Canada
  * Author: Varga, Steven <steven@vargaconsulting.ca>
  */
-#ifndef  H5CPP_FOPEN_HPP
-#define  H5CPP_FOPEN_HPP
+#pragma once
 #include <string>
 #include <memory>
 
@@ -33,5 +32,3 @@ namespace h5{
 		return  h5::fd_t{fd};
     }
 }
-#endif
-

--- a/h5cpp/H5Fopen.hpp
+++ b/h5cpp/H5Fopen.hpp
@@ -4,7 +4,6 @@
  */
 #pragma once
 #include <string>
-#include <memory>
 
 /**
  * @namespace h5

--- a/h5cpp/H5Ialgorithm.hpp
+++ b/h5cpp/H5Ialgorithm.hpp
@@ -3,8 +3,7 @@
  * Author: Varga, Steven <steven@vargaconsulting.ca>
  */
 
-#ifndef  H5CPPI_ALGORITHM_HPP
-#define  H5CPPI_ALGORITHM_HPP
+#pragma once
 #include <string>
 #include <vector>
 #include <stdexcept>
@@ -43,5 +42,3 @@ namespace h5 {
         return files;
     }
 }
-#endif
-

--- a/h5cpp/H5Iall.hpp
+++ b/h5cpp/H5Iall.hpp
@@ -3,8 +3,7 @@
  * Author: Varga, Steven <steven@vargaconsulting.ca>
  */
 
-#ifndef  H5CPP_IALL_HPP
-#define  H5CPP_IALL_HPP
+#pragma once
 #include <string>
 #include <vector>
 #include <tuple>
@@ -214,7 +213,6 @@ namespace h5 {
 	#undef H5CPP__defpid_t
 	#undef H5CPP__defhid_t
 }
-#endif
 // T ::= impl::T_ 
 // prop_t<h5::fapl_t, default_fapl,  capi, capi_call>
 // prop_base< prop_t<phid_t,init,capi,capi_call>, phid_t >

--- a/h5cpp/H5Marma.hpp
+++ b/h5cpp/H5Marma.hpp
@@ -2,8 +2,7 @@
  * Copyright (c) 2018-2020 Steven Varga, Toronto,ON Canada
  * Author: Varga, Steven <steven@vargaconsulting.ca>
  */
-#ifndef  H5CPP_ARMA_HPP 
-#define  H5CPP_ARMA_HPP
+#pragma once
 
 //#include "H5Tmeta.hpp"
 
@@ -80,5 +79,4 @@ namespace h5::impl {
 			return h5::arma::colmat<T>( dims[2], dims[0], dims[1] );
 	}};
 }
-#endif
 #endif

--- a/h5cpp/H5Mblaze.hpp
+++ b/h5cpp/H5Mblaze.hpp
@@ -2,8 +2,7 @@
  * Copyright (c) 2018-2020 Steven Varga, Toronto,ON Canada
  * Author: Varga, Steven <steven@vargaconsulting.ca>
  */
-#ifndef  H5CPP_BLAZE_HPP 
-#define  H5CPP_BLAZE_HPP
+#pragma once
 
 #if defined(_BLAZE_MATH_MODULE_H_) || defined(H5CPP_USE_BLAZE)
 namespace h5::blaze {
@@ -67,5 +66,4 @@ namespace h5::impl {
 	}};
 }
 
-#endif
 #endif

--- a/h5cpp/H5Mdlib.hpp
+++ b/h5cpp/H5Mdlib.hpp
@@ -2,8 +2,7 @@
  * Copyright (c) 2018-2020 Steven Varga, Toronto,ON Canada
  * Author: Varga, Steven <steven@vargaconsulting.ca>
  */
-#ifndef  H5CPP_DLIB_HPP 
-#define  H5CPP_DLIB_HPP
+#pragma once
 
 #if defined(DLIB_MATRIx_HEADER) || defined(H5CPP_USE_DLIB)
 namespace h5::dlib {
@@ -47,5 +46,4 @@ namespace h5::impl {
 			return h5::dlib::rowmat<T>( dims[1], dims[0] );
 	}};
 }
-#endif
 #endif

--- a/h5cpp/H5Meigen.hpp
+++ b/h5cpp/H5Meigen.hpp
@@ -2,8 +2,7 @@
  * Copyright (c) 2018-2020 Steven Varga, Toronto,ON Canada
  * Author: Varga, Steven <steven@vargaconsulting.ca>
  */
-#ifndef  H5CPP_EIGEN_HPP 
-#define H5CPP_EIGEN_HPP
+#pragma once
 #include <hdf5.h>
 #include "H5Tmeta.hpp"
 #include <tuple>
@@ -120,5 +119,4 @@ namespace h5::impl {
 	}};
 }
 
-#endif
 #endif

--- a/h5cpp/H5Mitpp.hpp
+++ b/h5cpp/H5Mitpp.hpp
@@ -2,8 +2,7 @@
  * Copyright (c) 2018-2020 Steven Varga, Toronto,ON Canada
  * Author: Varga, Steven <steven@vargaconsulting.ca>
  */
-#ifndef  H5CPP_ITPP_HPP 
-#define  H5CPP_ITPP_HPP
+#pragma once
 
 
 #if defined(MAT_H) || defined(H5CPP_USE_ITPP_MATRIX)
@@ -61,5 +60,4 @@ namespace h5::impl {
 			return h5::itpp::rowvec<T>( dims[0] );
 	}};
 }
-#endif
 #endif

--- a/h5cpp/H5Mstl.hpp
+++ b/h5cpp/H5Mstl.hpp
@@ -3,8 +3,7 @@
  * Author: Varga, Steven <steven@vargaconsulting.ca>
  */
 
-#ifndef  H5CPP_STL_HPP
-#define  H5CPP_STL_HPP
+#pragma once
 #include <string>
 #include <vector>
 #include <array>
@@ -80,4 +79,3 @@ namespace h5::impl {
 			return std::vector<T>( dims[0] );
 	}};
 }
-#endif

--- a/h5cpp/H5Mublas.hpp
+++ b/h5cpp/H5Mublas.hpp
@@ -2,8 +2,7 @@
  * Copyright (c) 2018-2020 Steven Varga, Toronto,ON Canada
  * Author: Varga, Steven <steven@vargaconsulting.ca>
  */
-#ifndef  H5CPP_UBLAS_HPP 
-#define  H5CPP_UBLAS_HPP
+#pragma once
 
 #if defined(_BOOST_UBLAS_MATRIX_) || defined(H5CPP_USE_UBLAS_MATRIX)
 namespace h5::ublas {
@@ -60,5 +59,4 @@ namespace h5::impl {
 			return h5::ublas::rowvec<T>( dims[0] );
 	}};
 }
-#endif
 #endif

--- a/h5cpp/H5Pall.hpp
+++ b/h5cpp/H5Pall.hpp
@@ -2,8 +2,7 @@
  * Copyright (c) 2018-2020 Steven Varga, Toronto,ON Canada
  * Author: Varga, Steven <steven@vargaconsulting.ca>
  */
-#ifndef  H5CPP_PALL_HPP
-#define  H5CPP_PALL_HPP
+#pragma once
 #include <array>
 #include <tuple>
 #include <initializer_list>
@@ -403,6 +402,4 @@ namespace h5 {
 	const static h5::fapl_t default_fapl = static_cast<h5::fapl_t>( H5P_DEFAULT );
 	const static h5::fcpl_t default_fcpl = static_cast<h5::fcpl_t>( H5P_DEFAULT );
 }
-
-#endif
 

--- a/h5cpp/H5Pdapl.hpp
+++ b/h5cpp/H5Pdapl.hpp
@@ -2,8 +2,7 @@
  * Copyright (c) 2018-2020 Steven Varga, Toronto,ON Canada
  * Author: Varga, Steven <steven@vargaconsulting.ca>
  */
-#ifndef  H5CPP_PDAPL_HPP
-#define  H5CPP_PDAPL_HPP
+#pragma once
 
 #define H5CPP_DAPL_HIGH_THROUGHPUT "h5cpp_dapl_highthroughput"
 
@@ -46,4 +45,3 @@ namespace h5 {
 	const static h5::dapl_t default_dapl = static_cast<h5::dapl_t>(  H5Pcreate(H5P_DATASET_ACCESS) );
 }
 
-#endif

--- a/h5cpp/H5Pdcpl.hpp
+++ b/h5cpp/H5Pdcpl.hpp
@@ -4,8 +4,7 @@
  *
  */
 
-#ifndef  H5CPP_PDCPL_HPP
-#define  H5CPP_PDCPL_HPP
+#pragma once
 
 #define H5CPP_DCPL_MULTI_DATASET "h5cpp_dcpl_multi_dataset"
 
@@ -79,4 +78,3 @@ namespace h5 {
     const static h5::dcpl_t dcpl = static_cast<h5::dcpl_t>( H5P_DEFAULT );
     const static h5::dcpl_t default_dcpl = static_cast<h5::dcpl_t>( H5P_DEFAULT );
 }
-#endif

--- a/h5cpp/H5Rall.hpp
+++ b/h5cpp/H5Rall.hpp
@@ -2,8 +2,7 @@
  * Copyright (c) 2018-2021 Steven Varga, Toronto,ON Canada
  * Author: Varga, Steven <steven@vargaconsulting.ca>
  */
-#ifndef  H5CPP_RALL_HPP
-#define  H5CPP_RALL_HPP
+#pragma once
 #include <initializer_list>
 #include <string>
 #include <tuple>
@@ -159,4 +158,3 @@ namespace h5::exp {
 	
 
 }
-#endif 

--- a/h5cpp/H5Sall.hpp
+++ b/h5cpp/H5Sall.hpp
@@ -3,8 +3,7 @@
  * Author: Varga, Steven <steven@vargaconsulting.ca>
  */
 
-#ifndef  H5CPP_SALL_HPP
-#define  H5CPP_SALL_HPP
+#pragma once
 #include <array>
 #include <tuple>
 #include <initializer_list>
@@ -175,4 +174,3 @@ namespace h5::impl {
 	}
 }
 
-#endif

--- a/h5cpp/H5Tall.hpp
+++ b/h5cpp/H5Tall.hpp
@@ -2,8 +2,7 @@
  * Copyright (c) 2018-2020 Steven Varga, Toronto,ON Canada
  * Author: Varga, Steven <steven@vargaconsulting.ca>
  */
-#ifndef H5CPP_TALL_HPP
-#define H5CPP_TALL_HPP
+#pragma once
 #include <type_traits>
 #include <ostream>
 #include <optional>
@@ -228,4 +227,3 @@ public:
 };
 } // namespace h5::meta
 
-#endif

--- a/h5cpp/H5Tconversion.hpp
+++ b/h5cpp/H5Tconversion.hpp
@@ -2,8 +2,7 @@
  * Copyright (c) 2018 - 2021 vargaconsulting, Toronto,ON Canada
  * Author: Varga, Steven <steven@vargaconsulting.ca>
  */
-#ifndef H5CPP_TCONVERSION_HPP
-#define H5CPP_TCONVERSION_HPP
+#pragma once
 
 #include <hdf5.h>
 #include <iostream>
@@ -104,4 +103,3 @@ namespace h5::impl{
 namespace {
 
 }
-#endif

--- a/h5cpp/H5Tmeta.hpp
+++ b/h5cpp/H5Tmeta.hpp
@@ -1,10 +1,8 @@
-
 /*
  * Copyright (c) 2018 - 2021 vargaconsulting, Toronto,ON Canada
  * Author: Varga, Steven <steven@vargaconsulting.ca>
  */
-#ifndef  H5CPP_META456_HPP 
-#define  H5CPP_META456_HPP
+#pragma once
 
 #include "H5Iall.hpp"
 #include "H5meta.hpp"
@@ -533,5 +531,3 @@ namespace h5::meta {
 
     //template <class T> struct 
 }
-
-#endif

--- a/h5cpp/H5Tmeta.hpp
+++ b/h5cpp/H5Tmeta.hpp
@@ -18,9 +18,7 @@
 #include <map>
 #include <unordered_set>
 #include <unordered_map>
-#include <stack>
-#include <queue>
-#include <any>
+
 #include <tuple>
 #include <complex>
 #include <cstddef>

--- a/h5cpp/H5Zall.hpp
+++ b/h5cpp/H5Zall.hpp
@@ -4,11 +4,9 @@
  */
 #pragma once
 
-#include <iomanip>
 #include <string>
 #include <stdexcept>
 #include <zlib.h>
-#include <cmath>
 
 namespace h5::impl::filter {
 	// TODO: figure something out to map c++ filters to C calls? 

--- a/h5cpp/H5Zall.hpp
+++ b/h5cpp/H5Zall.hpp
@@ -2,8 +2,7 @@
  * Copyright (c) 2018-2020 Steven Varga, Toronto,ON Canada
  * Author: Varga, Steven <steven@vargaconsulting.ca>
  */
-#ifndef  H5CPP_ZALL_HPP
-#define  H5CPP_ZALL_HPP
+#pragma once
 
 #include <iomanip>
 #include <string>
@@ -101,4 +100,3 @@ namespace h5::impl::filter {
 
 
 }
-#endif

--- a/h5cpp/H5Zpipeline.hpp
+++ b/h5cpp/H5Zpipeline.hpp
@@ -8,7 +8,6 @@
 #include <algorithm>
 #include <ostream>
 #include <cstring>
-#include <cstdlib>
 #include <utility>
 
 namespace h5 {

--- a/h5cpp/H5Zpipeline.hpp
+++ b/h5cpp/H5Zpipeline.hpp
@@ -2,8 +2,7 @@
  * Copyright (c) 2018-2020 Steven Varga, Toronto,ON Canada
  * Author: Varga, Steven <steven@vargaconsulting.ca>
  */
-#ifndef  H5CPP_PIPELINE_HPP
-#define  H5CPP_PIPELINE_HPP
+#pragma once
 #include <memory>
 #include <stdexcept>
 #include <algorithm>
@@ -280,4 +279,3 @@ inline std::ostream& operator<<(std::ostream &os, const h5::impl::pipeline_t<T>&
     os << "n: " << p.n;
 	return os;
 }
-#endif

--- a/h5cpp/H5Zpipeline_basic.hpp
+++ b/h5cpp/H5Zpipeline_basic.hpp
@@ -4,7 +4,6 @@
  */
 #pragma once
 #include <stdexcept>
-#include <iostream>
 
 inline void h5::impl::basic_pipeline_t::write_chunk_impl( const hsize_t* offset, size_t nbytes, const void* data ){
 

--- a/h5cpp/H5Zpipeline_basic.hpp
+++ b/h5cpp/H5Zpipeline_basic.hpp
@@ -2,8 +2,7 @@
  * Copyright (c) 2018-2020 Steven Varga, Toronto,ON Canada
  * Author: Varga, Steven <steven@vargaconsulting.ca>
  */
-#ifndef  H5CPP_PIPELINE_BASIC_HPP
-#define  H5CPP_PIPELINE_BASIC_HPP
+#pragma once
 #include <stdexcept>
 #include <iostream>
 
@@ -62,4 +61,3 @@ inline void h5::impl::basic_pipeline_t::read_chunk_impl( const hsize_t* offset, 
 	}
 }
 
-#endif

--- a/h5cpp/H5capi.hpp
+++ b/h5cpp/H5capi.hpp
@@ -2,8 +2,7 @@
  * Copyright (c) 2018-2020 Steven Varga, Toronto,ON Canada
  * Author: Varga, Steven <steven@vargaconsulting.ca>
  */
-#ifndef  H5CPP_CAPI_HPP
-#define  H5CPP_CAPI_HPP
+#pragma once
 #include <type_traits>
 #include <stdexcept>
 #include <string>
@@ -220,5 +219,3 @@ namespace h5 {
 		return h5::get_fill_value(dcpl, type, size);
 	}
 }
-#endif
-

--- a/h5cpp/H5config.hpp
+++ b/h5cpp/H5config.hpp
@@ -2,8 +2,7 @@
  * Copyright (c) 2018-2020 Steven Varga, Toronto,ON Canada
  * Author: Varga, Steven <steven@vargaconsulting.ca>
  */
-#ifndef H5CPP_CONFIG_H
-#define H5CPP_CONFIG_H
+#pragma once
 
 // to activate must include: #include "rest_vol_public.h"
 // see: https://bitbucket.hdfgroup.org/users/jhenderson/repos/rest-vol/browse
@@ -173,10 +172,4 @@
  *  **off** and **on**.  Typically used when failure is information: checking existence of [dataset|path] by call-fail pattern, etc...  
  *  \hdf5_links
  */
-
-#endif
-
-
-
-
 

--- a/h5cpp/H5cout.hpp
+++ b/h5cpp/H5cout.hpp
@@ -2,8 +2,7 @@
  * Copyright (c) 2018-2020 Steven Varga, Toronto,ON Canada
  * Author: Varga, Steven <steven@vargaconsulting.ca>
  */
-#ifndef  H5CPP_STD_COUT
-#define  H5CPP_STD_COUT
+#pragma once
 #include <ostream>
 #include <string>
 #include <vector>
@@ -120,6 +119,4 @@ std::ostream& operator<<(std::ostream& os, const std::vector<T>& vec){
 return os;
 }
 
-
-#endif
 

--- a/h5cpp/H5meta.hpp
+++ b/h5cpp/H5meta.hpp
@@ -3,8 +3,7 @@
  * Author: Varga, Steven <steven@vargaconsulting.ca>
  *
  */
-#ifndef  H5CPP_META_HPP 
-#define  H5CPP_META_HPP
+#pragma once
 
 #include "compat.hpp"
 #include <type_traits>
@@ -275,4 +274,3 @@ namespace h5::meta {
 template<class T> struct extent_to_string :
     h5::meta::impl::parse<std::rank<T>::value, T>{};
 }
-#endif

--- a/h5cpp/H5misc.hpp
+++ b/h5cpp/H5misc.hpp
@@ -3,8 +3,7 @@
  * Author: Varga, Steven <steven@vargaconsulting.ca>
  */
 
-#ifndef  H5CPP_MISC_HPP
-#define  H5CPP_MISC_HPP
+#pragma once
 #include <complex>
 #include <string>
 #include <vector>
@@ -111,5 +110,3 @@ namespace h5::impl {
     template <typename T>
         using unique_ptr = std::unique_ptr<T, h5::impl::free>;
 }
-#endif
-

--- a/h5cpp/compat.hpp
+++ b/h5cpp/compat.hpp
@@ -3,8 +3,7 @@
  * Author: Varga, Steven <steven@vargaconsulting.ca>
  */
 
-#ifndef  H5CPP_COMPAT_HPP
-#define  H5CPP_COMPAT_HPP
+#pragma once
 
 #include <hdf5.h>
 #include <cstddef>
@@ -86,4 +85,3 @@ namespace h5::meta::compat {
     template <class To, template<class...> class Op, class... Args>
     constexpr bool is_detected_convertible_v = is_detected_convertible<To, Op, Args...>::value;
 }
-#endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -51,6 +51,7 @@ endfunction()
 add_test_case(example)
 
 # test content lands in issue/94
+add_test_case(H5Adelete)
 add_test_case(H5compat)
 add_test_case(H5Dgather)
 add_test_case(H5meta)

--- a/test/H5Adelete.cpp
+++ b/test/H5Adelete.cpp
@@ -1,0 +1,37 @@
+#include <hdf5.h>
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/all>
+#include <h5cpp/core>
+#include <h5cpp/H5Fcreate.hpp>
+#include <h5cpp/H5Fopen.hpp>
+#include <h5cpp/H5Dcreate.hpp>
+#include <h5cpp/H5Dopen.hpp>
+#include <h5cpp/H5Acreate.hpp>
+#include <h5cpp/H5Aopen.hpp>
+#include <h5cpp/H5Awrite.hpp>
+#include <h5cpp/H5Adelete.hpp>
+#include "support/fixture.hpp"
+
+TEST_CASE("h5::adelete removes an existing attribute") {
+    h5::test::file_fixture_t f("test-adelete.h5");
+    h5::ds_t ds = h5::create<int>(f.fd, "dataset", h5::current_dims_t{1});
+
+    ds["attr_to_delete"] = 42;
+    CHECK(H5Aexists(static_cast<hid_t>(ds), "attr_to_delete") > 0);
+
+    h5::adelete(ds, "attr_to_delete");
+    CHECK(H5Aexists(static_cast<hid_t>(ds), "attr_to_delete") == 0);
+}
+
+TEST_CASE("h5::adelete throws on non-existent attribute") {
+    h5::test::file_fixture_t f("test-adelete-missing.h5");
+    h5::ds_t ds = h5::create<int>(f.fd, "dataset", h5::current_dims_t{1});
+
+    bool threw = false;
+    try {
+        h5::adelete(ds, "missing_attr");
+    } catch (const h5::error::io::attribute::delete_&) {
+        threw = true;
+    }
+    CHECK(threw);
+}


### PR DESCRIPTION
## Summary

Issue #131 — codebase cleanup with two focused changes:

### 1. Pragma-once migration
Replaced `#ifndef/#define/#endif` include guards with `#pragma once` across 40 header files in `h5cpp/`.

### 2. `h5::adelete()` implementation
- Filled in the previously empty `H5Adelete.hpp` stub with a working `h5::adelete()` template
- Added missing `h5::error::io::attribute::delete_` exception type to `H5Eall.hpp`
- Added unit tests in `test/H5Adelete.cpp` covering:
  - successful deletion of an existing attribute
  - exception thrown on deletion of a non-existent attribute

### Validation
- CMake configure: ✅ passed
- Build: ✅ passed (all 7 test binaries)
- Test suite: ✅ 7/7 passed