### PR TITLE
[#133] Build and execute examples on all CI matrix entries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,7 @@ jobs:
             -DCMAKE_CXX_STANDARD=23
             -DCMAKE_BUILD_TYPE=Release
             -DH5CPP_BUILD_TESTS=ON
+            -DH5CPP_BUILD_EXAMPLES=ON
           )
 
           if [[ -n "${HDF5_ROOT:-}" ]]; then
@@ -379,6 +380,7 @@ jobs:
             -DCMAKE_C_FLAGS="--coverage -O0 -g" \
             -DCMAKE_CXX_FLAGS="--coverage -O0 -g" \
             -DH5CPP_BUILD_TESTS=ON
+            -DH5CPP_BUILD_EXAMPLES=ON
 
       - name: Build
         shell: bash


### PR DESCRIPTION
Closes #133.

Adds -DH5CPP_BUILD_EXAMPLES=ON to all CI configure steps (Linux, macOS, Windows, Coverage) so examples compile and run on every matrix entry.