### PR TITLE
[#163] ci, skip full matrix on release — staging CI is sufficient

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,9 @@ env:
 
 on:
   push:
-    branches: [ release, staging ]
+    branches: [ staging ]
   pull_request:
-    branches: [ release, staging ]
+    branches: [ staging ]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

- Remove `release` from `push` and `pull_request` branch triggers in `ci.yml`
- Full matrix (Ubuntu × gcc/clang, macOS, Windows, coverage) now runs on `staging` only
- `workflow_dispatch` preserved for manual one-off verification on `release` if a hotfix ever lands there directly

## Why

When `release` is always a fast-forward of `staging`, re-running CI on `release` is pure duplication — same tree, same tests, same 10-minute wait, guaranteed same result.

## Test plan

- [ ] Confirm CI does not trigger on a push to `release`
- [ ] Confirm CI continues to trigger on pushes to `staging`
- [ ] Confirm `workflow_dispatch` is still available on `release`