### PR TITLE
[#133]:svarga:ci, build and execute examples on all CI matrix entries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -489,7 +489,7 @@ jobs:
             -DCMAKE_CXX_COMPILER=g++-14 \
             -DCMAKE_C_FLAGS="--coverage -O0 -g" \
             -DCMAKE_CXX_FLAGS="--coverage -O0 -g" \
-            -DH5CPP_BUILD_TESTS=ON
+            -DH5CPP_BUILD_TESTS=ON \
             -DH5CPP_BUILD_EXAMPLES=ON
 
       - name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,6 +282,7 @@ jobs:
             -DCMAKE_CXX_STANDARD=23
             -DCMAKE_BUILD_TYPE=Release
             -DH5CPP_BUILD_TESTS=ON
+            -DH5CPP_BUILD_EXAMPLES=ON
           )
 
           if [[ -n "${HDF5_ROOT:-}" ]]; then
@@ -489,6 +490,7 @@ jobs:
             -DCMAKE_C_FLAGS="--coverage -O0 -g" \
             -DCMAKE_CXX_FLAGS="--coverage -O0 -g" \
             -DH5CPP_BUILD_TESTS=ON
+            -DH5CPP_BUILD_EXAMPLES=ON
 
       - name: Build
         shell: bash

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -77,6 +77,16 @@ if(NOT TARGET libeigen3)
 	endif()
 endif()
 
+# Expose find_package-style variables from vendored targets so the conditional
+# example blocks below work regardless of whether the libraries were found via
+# find_package or via the vendored thirdparty subdirectory.
+if(TARGET libarmadillo)
+    set(ARMADILLO_FOUND TRUE)
+endif()
+if(TARGET libeigen3)
+    set(Eigen3_FOUND TRUE)
+endif()
+
 list(APPEND LIBS ${HDF5_C_LIBRARIES} ZLIB::ZLIB libh5cpp-libdeflate)
 list(APPEND INCLUDE_DIRS ${CMAKE_SOURCE_DIR} ${HDF5_INCLUDE_DIRS}  ${ZLIB_INCLUDE_DIRS})
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -90,7 +90,7 @@ endif()
 list(APPEND LIBS ${HDF5_C_LIBRARIES} ZLIB::ZLIB libh5cpp-libdeflate)
 list(APPEND INCLUDE_DIRS ${CMAKE_SOURCE_DIR} ${HDF5_INCLUDE_DIRS}  ${ZLIB_INCLUDE_DIRS})
 
-include_directories(BEFORE ${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/..)
+include_directories(BEFORE ${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/.. ${HDF5_C_INCLUDE_DIRS})
 
 if( H5CPP_COMPILER_FOUND )
 	add_custom_target(h5cpp-compiler-generated ALL
@@ -197,7 +197,7 @@ endif()
 if( ${ARMADILLO_FOUND} )
 ## attributes ###
 add_executable(examples-attributes EXCLUDE_FROM_ALL "attributes/attributes.cpp")
-target_link_libraries(examples-attributes ${LIBS} )
+target_link_libraries(examples-attributes ${LIBS} libarmadillo)
 add_dependencies(examples examples-attributes)
 endif()
 
@@ -209,7 +209,7 @@ add_dependencies(examples examples-basics)
 if( ${ARMADILLO_FOUND} )
 ## compound ###
 add_executable(examples-compound EXCLUDE_FROM_ALL "compound/struct.cpp")
-target_link_libraries(examples-compound ${LIBS} )
+target_link_libraries(examples-compound ${LIBS} libarmadillo)
 add_dependencies(examples examples-compound)
 endif()
 
@@ -224,7 +224,7 @@ endif()
 if( ${ARMADILLO_FOUND} )
 ## datasets ###
 add_executable(examples-datasets EXCLUDE_FROM_ALL "datasets/datasets.cpp")
-target_link_libraries(examples-datasets ${LIBS} )
+target_link_libraries(examples-datasets ${LIBS} libarmadillo)
 add_dependencies(examples examples-datasets)
 endif()
 
@@ -249,7 +249,7 @@ add_dependencies(examples examples-twobit)
 if( ${ARMADILLO_FOUND} )
 ## optimized ###
 add_executable(examples-optimized EXCLUDE_FROM_ALL "optimized/optimized.cpp")
-target_link_libraries(examples-optimized ${LIBS} )
+target_link_libraries(examples-optimized ${LIBS} libarmadillo)
 add_dependencies(examples examples-optimized)
 endif()
 
@@ -278,7 +278,7 @@ add_dependencies(examples examples-string)
 if( ${ARMADILLO_FOUND} )
 ## transform ###
 add_executable(examples-transform EXCLUDE_FROM_ALL "transform/transform.cpp")
-target_link_libraries(examples-transform ${LIBS} )
+target_link_libraries(examples-transform ${LIBS} libarmadillo)
 add_dependencies(examples examples-transform)
 endif()
 

--- a/examples/groups/groups.cpp
+++ b/examples/groups/groups.cpp
@@ -37,7 +37,7 @@ int main() {
 		h5::awrite(gr, "temperature", 42.0);
 		h5::awrite(gr, "unit", "C");
 		h5::awrite(gr, "vector of ints", std::vector<int>({1,2,3,4,5}));
-		h5::awrite(gr, "initializer list", std::initializer_list({1,2,3,4,5}));
-		h5::awrite(gr, "strings", std::initializer_list({"first", "second", "third","..."}));
+		h5::awrite(gr, "initializer list", std::initializer_list<int>({1,2,3,4,5}));
+		h5::awrite(gr, "strings", std::initializer_list<const char*>({"first", "second", "third","..."}));
 	}
 }

--- a/examples/packet-table/packettable.cpp
+++ b/examples/packet-table/packettable.cpp
@@ -7,6 +7,7 @@
 #include <Eigen/Dense> // must include Eigen before <h5cpp/core>
 
 #include <cstdint>
+#include <numeric>
 #include "struct.h"
 #include <h5cpp/core>
 	// generated file must be sandwiched between core and io 


### PR DESCRIPTION
## Summary

- Enable `-DH5CPP_BUILD_EXAMPLES=ON` on all Linux, macOS, and Windows CI matrix entries (including the coverage job)
- Set `ARMADILLO_FOUND` / `Eigen3_FOUND` from vendored targets so the six armadillo/eigen-conditional examples (attributes, compound, datasets, optimized, transform, packet-table) are no longer silently skipped
- Add `${HDF5_C_INCLUDE_DIRS}` to `include_directories` — on Ubuntu CI, HDF5 installs to `/usr/include/hdf5/serial/` which is not in the default search path
- Add `libarmadillo` to the five examples that include `<armadillo>` but were missing the link target
- Fix `std::initializer_list` CTAD in `groups/groups.cpp` (clang-17/18 require explicit template args)
- Add `#include <numeric>` to `packet-table/packettable.cpp` for `std::iota` (MSVC strict, no transitive pull-in)
- Fix missing `\` in coverage configure step causing `-DH5CPP_BUILD_EXAMPLES=ON` to be executed as a bare shell command (exit code 127)

## Test plan

- [x] All 13 CI jobs green on final run (25816366063)
- [x] 55/55 example binaries build locally with zero errors