### PR TITLE
[#126]:svarga:fix, Eigen const_cast in data() accessors

### DIFF
--- a/h5cpp/H5Meigen.hpp
+++ b/h5cpp/H5Meigen.hpp
@@ -31,15 +31,25 @@ namespace h5::impl {
 	template<class T,int R,int C, int O> struct decay<::Eigen::Array<T,R,C,O>>{ using type = T; };
 	    
 
-	// TODO: remove const_cast
 	// get read access to datastaore
 	template<class T,int R,int C,int O, int MR=R,int MC=C>
-	T* data(const ::Eigen::Matrix<T,R,C,O,MR,MC>& ref ){
-			return const_cast<T*>( ref.data() );
+	const T* data(const ::Eigen::Matrix<T,R,C,O,MR,MC>& ref ){
+			return ref.data();
 	}
+	// read write access
 	template<class T,int R,int C,int O, int MR=R,int MC=C>
-	T* data(const ::Eigen::Array<T,R,C,O,MR,MC>& ref ){
-			return const_cast<T*>( ref.data() );
+	T* data(::Eigen::Matrix<T,R,C,O,MR,MC>& ref ){
+			return ref.data();
+	}
+	// get read access to datastaore
+	template<class T,int R,int C,int O, int MR=R,int MC=C>
+	const T* data(const ::Eigen::Array<T,R,C,O,MR,MC>& ref ){
+			return ref.data();
+	}
+	// read write access
+	template<class T,int R,int C,int O, int MR=R,int MC=C>
+	T* data(::Eigen::Array<T,R,C,O,MR,MC>& ref ){
+			return ref.data();
 	}
 	// determine rank and dimensions
 	// MATRICES


### PR DESCRIPTION
Closes #126

**Summary:**
Removes undefined-behaviour `const_cast` from `h5cpp/H5Meigen.hpp` by splitting the two `data()` overloads into proper const/non-const pairs, matching every other linalg adapter in the codebase.

**Changes:**
- `const T* data(const Eigen::Matrix&)` / `T* data(Eigen::Matrix&)`
- `const T* data(const Eigen::Array&)` / `T* data(Eigen::Array&)`
- Removed `// TODO: remove const_cast` comment

**Verification:**
- Clean build, zero warnings
- 34/34 tests passed