### PR TITLE
[#174]:svarga:refactor, eliminate compile warnings across core headers

### DIFF
--- a/examples/basics/basics.cpp
+++ b/examples/basics/basics.cpp
@@ -69,9 +69,10 @@ int main(){
 		// h5::lcpl_t lcpl = h5::create_path | h5::utf8; 
 	}
 	{ // all resources follow RAII idiom / managed
-		h5::fd_t fd = h5::create("001.h5", H5F_ACC_TRUNC);  // f5::fd_t is managed resource, will call H5Fclose upon leaving code block
-		hid_t ref = static_cast<hid_t>( fd ); 			    // static cast to hid_t is always allowed, ref must be treated as managed reference, 
-										  				    // must not call CAPI H5Fclose( ref )  on it. This explicit or implicit conversion 
+			h5::fd_t fd = h5::create("001.h5", H5F_ACC_TRUNC);  // f5::fd_t is managed resource, will call H5Fclose upon leaving code block
+			hid_t ref = static_cast<hid_t>( fd ); 			    // static cast to hid_t is always allowed, ref must be treated as managed reference,
+			(void)ref;
+			// must not call CAPI H5Fclose( ref )  on it. This explicit or implicit conversion
 										  				    // is to support CAPI interop.   
 	}
 	{ // file create example: 
@@ -108,4 +109,3 @@ int main(){
 	}
 
 }
-

--- a/examples/compound/utils.hpp
+++ b/examples/compound/utils.hpp
@@ -9,13 +9,13 @@ namespace h5::utils {
 	// template specialization 
 	template <> inline  std::vector<sn::example::Record> get_test_data( size_t n ){
 		std::vector<sn::example::Record> vec (n);
-		for(int i=0; i<n; i++ )
+		for(size_t i=0; i<n; i++ )
 			vec[i].idx = i;
 		return vec;
 	}
 	template <> inline  std::vector<int> get_test_data( size_t n ){
 		std::vector<int> vec (n);
-		for(int i=0; i<n; i++ )
+		for(size_t i=0; i<n; i++ )
 			vec[i] = i;
 		return vec;
 	}

--- a/examples/csv/csv.h
+++ b/examples/csv/csv.h
@@ -75,8 +75,7 @@ namespace io{
                        
 	                        void set_file_name(const char*file_name){
 	                                if(file_name != nullptr){
-	                                        strncpy(this->file_name, file_name, sizeof(this->file_name)-1);
-	                                        this->file_name[sizeof(this->file_name)-1] = '\0';
+	                                        std::snprintf(this->file_name, sizeof(this->file_name), "%s", file_name);
 	                                }else{
                                         this->file_name[0] = '\0';
                                 }
@@ -422,8 +421,7 @@ namespace io{
 
 	                void set_file_name(const char*file_name){
 	                        if(file_name != nullptr){
-	                                strncpy(this->file_name, file_name, sizeof(this->file_name)-1);
-	                                this->file_name[sizeof(this->file_name)-1] = '\0';
+	                                std::snprintf(this->file_name, sizeof(this->file_name), "%s", file_name);
 	                        }else{
                                 this->file_name[0] = '\0';
                         }

--- a/examples/csv/csv.h
+++ b/examples/csv/csv.h
@@ -73,11 +73,11 @@ namespace io{
                                 std::memset(file_name, 0, sizeof(file_name));
                         }
                        
-                        void set_file_name(const char*file_name){
-                                if(file_name != nullptr){
-                                        strncpy(this->file_name, file_name, sizeof(this->file_name));
-                                        this->file_name[sizeof(this->file_name)-1] = '\0';
-                                }else{
+	                        void set_file_name(const char*file_name){
+	                                if(file_name != nullptr){
+	                                        strncpy(this->file_name, file_name, sizeof(this->file_name)-1);
+	                                        this->file_name[sizeof(this->file_name)-1] = '\0';
+	                                }else{
                                         this->file_name[0] = '\0';
                                 }
                         }
@@ -420,11 +420,11 @@ namespace io{
                         set_file_name(file_name.c_str());
                 }
 
-                void set_file_name(const char*file_name){
-                        if(file_name != nullptr){
-                                strncpy(this->file_name, file_name, sizeof(this->file_name));
-                                this->file_name[sizeof(this->file_name)-1] = '\0';
-                        }else{
+	                void set_file_name(const char*file_name){
+	                        if(file_name != nullptr){
+	                                strncpy(this->file_name, file_name, sizeof(this->file_name)-1);
+	                                this->file_name[sizeof(this->file_name)-1] = '\0';
+	                        }else{
                                 this->file_name[0] = '\0';
                         }
                 }
@@ -1265,4 +1265,3 @@ namespace io{
         };
 }
 #endif
-

--- a/examples/csv/csv2hdf5.cpp
+++ b/examples/csv/csv2hdf5.cpp
@@ -34,7 +34,8 @@ int main(){
 	input_t row;                           // buffer to read line by line
 	char* ptr;      // indirection, as `read_row` doesn't take array directly
 	while(in.read_row(row.MasterRecordNumber, row.Hour, ptr, row.Latitude, row.Longitude)){
-		strncpy(row.ReportedLocation, ptr, STR_ARRAY_SIZE); // defined in struct.h
+		memset(row.ReportedLocation, 0, STR_ARRAY_SIZE);
+		strncpy(row.ReportedLocation, ptr, STR_ARRAY_SIZE - 1); // defined in struct.h
 		h5::append(pt, row);
 		std::cout << std::string(ptr) << "\n";
 	}

--- a/examples/datatypes/n-bit.cpp
+++ b/examples/datatypes/n-bit.cpp
@@ -75,11 +75,10 @@ int main(){
 		h5::write<bs::n_bit>(ds, V.data(), h5::count{12,8}); // single shot write
 
 		auto data = h5::read<std::vector<bs::n_bit>>(fd, "stl");
-		for( int i=0; i<V.size(); i++ )
+		for( size_t i=0; i<V.size(); i++ )
 			std::cout << static_cast<unsigned int>( data[i] ) << " ";
 		std::cout << "\n\ncomputing difference ||saved - read|| expecting norm to be zero:\n";
-		for( int i=0; i<V.size(); i++ )
+		for( size_t i=0; i<V.size(); i++ )
 			std::cout << abs(V[i].value - data[i].value) <<" ";
 	}
 }
-

--- a/examples/datatypes/n-bit.hpp
+++ b/examples/datatypes/n-bit.hpp
@@ -51,10 +51,9 @@ std::ostream& operator<<(std::ostream& os, const bitstring::n_bit& data){
 
 std::ostream& operator<<(std::ostream& os, const
 	 Eigen::Matrix<bitstring::n_bit, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>& M){
-	for( size_t i=0; i<M.rows(); i++){
-	   	for( size_t j=0; j<M.cols(); j++) os << static_cast<unsigned int>( M(i,j)) <<" ";
+	for( Eigen::Index i=0; i<M.rows(); i++){
+		for( Eigen::Index j=0; j<M.cols(); j++) os << static_cast<unsigned int>( M(i,j)) <<" ";
 		os<<std::endl;
 	}
 	return os;
 }
-

--- a/examples/datatypes/two-bit.cpp
+++ b/examples/datatypes/two-bit.cpp
@@ -25,10 +25,9 @@ int main(){
 	h5::write(fd,"data", vec); // single shot write
 	auto data = h5::read<std::vector<nm::two_bit>>(fd, "data");
 
-	for( int i=0; i<vec.size(); i++ )
+	for( size_t i=0; i<vec.size(); i++ )
 		std::cout << "[" << i << ": " << vec[i] << " "  <<"]";
 	std::cout << "\n\ncomputing difference ||saved - read|| expecting norm to be zero:\n";
-	for( int i=0; i<vec.size(); i++ )
+	for( size_t i=0; i<vec.size(); i++ )
 		std::cout << abs(vec[i].value - data[i].value) <<" ";
 }
-

--- a/examples/multi-tu/utils.hpp
+++ b/examples/multi-tu/utils.hpp
@@ -10,7 +10,7 @@ namespace h5 { namespace utils {
 	// template specialization 
 	template <> inline  std::vector<sn::example::Record> get_test_data( size_t n ){
 		std::vector<sn::example::Record> vec (n);
-		for(int i=0; i<n; i++ )
+		for(size_t i=0; i<n; i++ )
 			vec[i].idx = i;
 		return vec;
 	}

--- a/examples/packet-table/utils.hpp
+++ b/examples/packet-table/utils.hpp
@@ -10,7 +10,7 @@ namespace h5 { namespace utils {
 	// template specialization 
 	template <> inline  std::vector<sn::example::Record> get_test_data( size_t n ){
 		std::vector<sn::example::Record> vec (n);
-		for(int i=0; i<n; i++ )
+		for(size_t i=0; i<n; i++ )
 			vec[i].idx = i;
 		return vec;
 	}

--- a/examples/raw_memory/raw.cpp
+++ b/examples/raw_memory/raw.cpp
@@ -9,7 +9,6 @@
 int main(){
 	h5::fd_t fd = h5::create("raw.h5",H5F_ACC_TRUNC);
 
-    float  af[] = {values};
     double ad[] = {values};
 	double* ptr = static_cast<double*>( calloc(10,sizeof(double)) );
 
@@ -53,4 +52,3 @@ int main(){
 
 
 }
-

--- a/examples/stl/utils.hpp
+++ b/examples/stl/utils.hpp
@@ -9,7 +9,7 @@ namespace h5 { namespace utils {
 	// template specialization 
 	template <> inline  std::vector<sn::example::Record> get_test_data( size_t n ){
 		std::vector<sn::example::Record> vec (n);
-		for(int i=0; i<n; i++ )
+		for(size_t i=0; i<n; i++ )
 			vec[i].idx = i;
 		return vec;
 	}

--- a/h5cpp/H5Aread.hpp
+++ b/h5cpp/H5Aread.hpp
@@ -8,18 +8,19 @@
 namespace h5 {
 
 	//ARITHMETIC ELEMENT TYPES 
-	template <class T, class D=typename impl::decay<T>::type, class... args_t> inline
-	std::enable_if_t< std::is_integral_v<D> || std::is_floating_point_v<D>,
-	T> aread( const h5::ds_t& ds, const std::string& name, const h5::acpl_t& acpl = h5::default_acpl ){
+		template <class T, class D=typename impl::decay<T>::type, class... args_t> inline
+		std::enable_if_t< std::is_integral_v<D> || std::is_floating_point_v<D>,
+		T> aread( const h5::ds_t& ds, const std::string& name, const h5::acpl_t& acpl = h5::default_acpl ){
+			(void)acpl;
 
-		h5::at_t attr = h5::open(ds, name, h5::default_acpl);
+			h5::at_t attr = h5::open(ds, name, h5::default_acpl);
 		hid_t id;
 		H5CPP_CHECK_NZ( (id = H5Aget_space( static_cast<hid_t>(attr) )),
 			   h5::error::io::attribute::read, "couldn't get space...");
 		h5::sp_t file_space{id};
 		h5::current_dims_t current_dims;
 
-		int rank = get_simple_extent_dims(file_space, current_dims );
+			get_simple_extent_dims(file_space, current_dims );
 		using element_t = typename impl::decay<T>::type;
 		h5::dt_t<element_t> type;
 		T object = impl::get<T>::ctor( current_dims );
@@ -33,6 +34,7 @@ namespace h5 {
 	template <class T, class D=typename impl::decay<T>::type, class... args_t> inline
 	typename std::enable_if< !std::is_arithmetic<D>::value && (std::is_standard_layout_v<D> && std::is_trivial_v<D>) && !std::is_same<T,std::string>::value,
 	T>::type aread( const h5::ds_t& ds, const std::string& name, const h5::acpl_t& acpl = h5::default_acpl ){
+		(void)acpl;
 		h5::at_t attr = h5::open(ds, name, h5::default_acpl);
 		hid_t id;
 		H5CPP_CHECK_NZ( (id = H5Aget_space( static_cast<hid_t>(attr) )),
@@ -58,16 +60,17 @@ namespace h5 {
 	}
 
 	// STD::STRING
-	template <class T, class D=typename impl::decay<T>::type, class... args_t> inline
-	std::enable_if_t<std::is_same_v<D,std::string> || std::is_same_v<T,std::string>, //TODO: add char**
-	T> aread( const h5::ds_t& ds, const std::string& name, const h5::acpl_t& acpl = h5::default_acpl ){
-		h5::at_t attr = h5::open(ds, name, h5::default_acpl);
+		template <class T, class D=typename impl::decay<T>::type, class... args_t> inline
+		std::enable_if_t<std::is_same_v<D,std::string> || std::is_same_v<T,std::string>, //TODO: add char**
+		T> aread( const h5::ds_t& ds, const std::string& name, const h5::acpl_t& acpl = h5::default_acpl ){
+			(void)acpl;
+			h5::at_t attr = h5::open(ds, name, h5::default_acpl);
 		hid_t id;
 		H5CPP_CHECK_NZ( (id = H5Aget_space( static_cast<hid_t>(attr) )),
 			   h5::error::io::attribute::read, "couldn't get space...");
 		h5::sp_t file_space{id};
 		h5::current_dims_t current_dims;
-		int rank = get_simple_extent_dims(file_space, current_dims );
+			get_simple_extent_dims(file_space, current_dims );
 		h5::dt_t<char*> type;
 		T object = impl::get<T>::ctor( current_dims );
         size_t nelem = impl::nelements(current_dims);

--- a/h5cpp/H5Awrite.hpp
+++ b/h5cpp/H5Awrite.hpp
@@ -26,10 +26,11 @@ namespace h5 {
 				h5::error::io::attribute::write, "couldn't var length string attribute.");
 	}
 	// const char[]
-	template <class T, class P, class... args_t> inline std::enable_if_t<
-		std::is_array_v<T> && h5::impl::is_valid_attr<P>::value,
-	h5::at_t> awrite( const P& parent, const std::string& name, const T& ref, const h5::acpl_t& acpl = h5::default_acpl ){
-		h5::current_dims_t current_dims = impl::size( ref );
+		template <class T, class P, class... args_t> inline std::enable_if_t<
+			std::is_array_v<T> && h5::impl::is_valid_attr<P>::value,
+		h5::at_t> awrite( const P& parent, const std::string& name, const T& ref, const h5::acpl_t& acpl = h5::default_acpl ){
+			(void)acpl;
+			h5::current_dims_t current_dims = impl::size( ref );
 		using element_t = typename impl::decay<T>::type;
 		h5::at_t attr = ( H5Aexists(static_cast<hid_t>(parent), name.c_str() ) > 0 ) ?
 			h5::open(parent, name, h5::default_acpl) : h5::create<element_t>(parent, name, current_dims);
@@ -38,10 +39,11 @@ namespace h5 {
 	}
 
 	// general case but not: {std::initializer_list<T>} and const char[] 
-	template <class T, class P, class... args_t>
-	inline std::enable_if_t<!std::is_array_v<T> && h5::impl::is_valid_attr<P>::value,
-	h5::at_t> awrite( const P& parent, const std::string& name, const T& ref, const h5::acpl_t& acpl = h5::default_acpl ){
-		h5::current_dims_t current_dims = impl::size( ref );
+		template <class T, class P, class... args_t>
+		inline std::enable_if_t<!std::is_array_v<T> && h5::impl::is_valid_attr<P>::value,
+		h5::at_t> awrite( const P& parent, const std::string& name, const T& ref, const h5::acpl_t& acpl = h5::default_acpl ){
+			(void)acpl;
+			h5::current_dims_t current_dims = impl::size( ref );
 		using element_t = typename impl::decay<T>::type;
 		h5::at_t attr = ( H5Aexists(static_cast<hid_t>(parent), name.c_str() ) > 0 ) ?
 			h5::open(parent, name, h5::default_acpl) : h5::create<element_t>(parent, name, current_dims);
@@ -55,6 +57,7 @@ namespace h5 {
 	inline std::enable_if_t<h5::impl::is_valid_attr<P>::value,
     h5::at_t> awrite( const P& parent, const std::string& name, const std::initializer_list<T> ref,
 																		const h5::acpl_t& acpl = h5::default_acpl ) try {
+		(void)acpl;
 
 		h5::current_dims_t current_dims = impl::size( ref );
 		using element_t = typename impl::decay<std::initializer_list<T>>::type;
@@ -94,4 +97,3 @@ h5::at_t h5::at_t::operator=( const std::initializer_list<V> args ){
 	h5::awrite(ds, name, args);
 	return *this;
 }
-

--- a/h5cpp/H5Dcreate.hpp
+++ b/h5cpp/H5Dcreate.hpp
@@ -64,7 +64,8 @@ namespace h5 {
 		h5::current_dims_t current_dims_default{0}; // if no current dims_present 
 		// this mutable value will be referenced
 		const h5::current_dims_t& current_dims = arg::get(current_dims_default, args...);
-		const h5::max_dims_t& max_dims = arg::get(h5::max_dims_t{0}, args... );
+		h5::max_dims_t max_dims_default{0};
+		const h5::max_dims_t& max_dims = arg::get(max_dims_default, args... );
 		bool has_unlimited_dimension = false;
 		size_t rank = 0;
 		h5::sp_t space_id{H5I_UNINIT}; // set to invalid state 

--- a/h5cpp/H5Dread.hpp
+++ b/h5cpp/H5Dread.hpp
@@ -266,11 +266,10 @@ namespace h5 {
 		h5::sp_t file_space = h5::get_space(ds);
 	   	int rank = h5::get_simple_extent_ndims( file_space );
 
-		if( rank != count.rank ) throw h5::error::io::dataset::read( H5CPP_ERROR_MSG( h5::error::msg::rank_mismatch ));
-		h5::dt_t<char*> mem_type;
-		hid_t dapl = h5::get_access_plist( ds );
+			if( rank != count.rank ) throw h5::error::io::dataset::read( H5CPP_ERROR_MSG( h5::error::msg::rank_mismatch ));
+			h5::dt_t<char*> mem_type;
 
-		T ref = impl::get<T>::ctor( count );
+			T ref = impl::get<T>::ctor( count );
 		size_t nelem = impl::nelements(size);
 		char ** ptr = static_cast<char **>(
 										malloc( nelem * sizeof(char *)));
@@ -280,8 +279,8 @@ namespace h5 {
 		H5CPP_CHECK_NZ( H5Dread(
 					static_cast<hid_t>( ds ), static_cast<hid_t>(mem_type), static_cast<hid_t>(mem_space),
 					static_cast<hid_t>(file_space),	static_cast<hid_t>(dxpl), ptr ), h5::error::io::dataset::read, h5::error::msg::read_dataset);
-		for(int i=0; i<nelem; i++)
-				if( ptr[i] != nullptr )
+			for(size_t i=0; i<nelem; i++)
+					if( ptr[i] != nullptr )
 						ref[i] = std::string( ptr[i] );
 		H5Dvlen_reclaim (mem_type, mem_space, H5P_DEFAULT, ptr);
 		free(ptr);

--- a/h5cpp/H5Dwrite.hpp
+++ b/h5cpp/H5Dwrite.hpp
@@ -105,7 +105,7 @@ namespace h5 {
 				const h5::offset_t& offset = arg::get( h5::default_offset, args...);
 				const h5::stride_t& stride = arg::get( h5::default_stride, args...);
 				if constexpr( tblock::present ){ // we have to normalise `count` such that `size[i] = count[i] * block[i]` holds
-					for(hsize_t i=0; i < rank; i++) count[i] /= block[i];
+					for(int i=0; i < rank; i++) count[i] /= block[i];
 					err = H5Sselect_hyperslab(file_space, H5S_SELECT_SET, *offset, *stride, *count, *block);
 				} else { // we have to convert h5::count_t{..} to h5::block{..} and initiate a single block transfer
 					h5::block_t block_ = static_cast<h5::block_t>(count);

--- a/h5cpp/H5Dwrite.hpp
+++ b/h5cpp/H5Dwrite.hpp
@@ -337,11 +337,10 @@ namespace h5 {
 	* 	h5::current_dims{vec.length()}, h5::max_dims{H5S_UNLIMITED}, h5::chunk{1024} | h5::gzip{9});
 	* @endcode 
  	*/ 
-	template <class T, class... args_t,
-		class = std::enable_if_t<!std::is_pointer_v<std::decay_t<T>>>>
-	inline h5::ds_t write( const h5::fd_t& fd, const std::string& dataset_path, const T& ref,  args_t&&... args  ){
-		using tcount  = typename arg::tpos<const h5::count_t&, const args_t&...>;
-		h5::ds_t ds; // initialized to H5I_UNINIT
+		template <class T, class... args_t,
+			class = std::enable_if_t<!std::is_pointer_v<std::decay_t<T>>>>
+		inline h5::ds_t write( const h5::fd_t& fd, const std::string& dataset_path, const T& ref,  args_t&&... args  ){
+			h5::ds_t ds; // initialized to H5I_UNINIT
 		// find out if we have to create the dataset
 		h5::mute();
 			// Returns a negative value when the function fails and may return a negative value if the link does not exist.

--- a/h5cpp/H5Ialgorithm.hpp
+++ b/h5cpp/H5Ialgorithm.hpp
@@ -8,9 +8,10 @@
 #include <vector>
 #include <stdexcept>
 
-namespace h5::impl {
-	inline static herr_t iterate_callback( ::hid_t gid, const char *name, const H5L_info_t *info, void *op_data){
-		// this must not throw error, CAPI has to clean up
+	namespace h5::impl {
+		inline static herr_t iterate_callback( ::hid_t gid, const char *name, const H5L_info_t *info, void *op_data){
+			(void)gid; (void)info;
+			// this must not throw error, CAPI has to clean up
 		try {
 			std::vector<std::string> *data =  static_cast<std::vector<std::string>* >(op_data);
 			data->push_back( std::string(name) );
@@ -33,12 +34,14 @@ namespace h5 {
         return files;
     }
 	//FIXME: to be implemented
-    inline std::vector<std::string> bfs(const h5::fd_t& fd,  const std::string& directory ){
-        std::vector<std::string> files;
-        return files;
-    }
-	inline std::vector<std::string> dfs(const h5::fd_t& fd,  const std::string& directory ){
-        std::vector<std::string> files;
+	    inline std::vector<std::string> bfs(const h5::fd_t& fd,  const std::string& directory ){
+			(void)fd; (void)directory;
+	        std::vector<std::string> files;
+	        return files;
+	    }
+		inline std::vector<std::string> dfs(const h5::fd_t& fd,  const std::string& directory ){
+			(void)fd; (void)directory;
+	        std::vector<std::string> files;
         return files;
     }
 }

--- a/h5cpp/H5Iall.hpp
+++ b/h5cpp/H5Iall.hpp
@@ -130,13 +130,15 @@ namespace h5::impl::detail {
 		//hid_t& operator =( ::hid_t ref ) {}
 
 
-		hid_t& operator |=( const hid_t& ref){
-			return *this;
-		}
+			hid_t& operator |=( const hid_t& ref){
+				(void)ref;
+				return *this;
+			}
 
-		hid_t& operator |( const hid_t& ref){
-			return *this;
-		}
+			hid_t& operator |( const hid_t& ref){
+				(void)ref;
+				return *this;
+			}
 	};
 	/*dataset id*/ //FIXME: eliminate extra field: ds  @see HDF5 CAPI BUG: https://jira.hdfgroup.org/browse/HDFFV-10934
 	template<class T, capi_close_t capi_close>

--- a/h5cpp/H5Mstl.hpp
+++ b/h5cpp/H5Mstl.hpp
@@ -66,17 +66,17 @@ namespace h5::impl {
 	T*> data( T& ref ){ return &ref; }
 	//template <class T> inline std::enable_if_t<std::is_integral_v<T>,
 	//	const T*> data( const T& ref ){ return &ref; }
-	// 5.) obtain dimensions of extents
-	template <class T> inline constexpr std::enable_if_t< impl::is_scalar<T>::value,
-		std::array<size_t,0>> size( T value ){ return{}; }
+		// 5.) obtain dimensions of extents
+		template <class T> inline constexpr std::enable_if_t< impl::is_scalar<T>::value,
+			std::array<size_t,0>> size( T ){ return{}; }
 	template <class T, class A> inline std::array<size_t,1> size( const std::vector<T, A>& ref ){ return {ref.size()}; }
 	template <class T> inline std::array<size_t,1> size( const std::initializer_list<T>& ref ){ return {ref.size()}; }
 	template <class T> inline constexpr std::enable_if_t<!impl::is_scalar<T>::value,
 		std::array<size_t,0>> size( const T& ){ return{}; }
-	// 6.) ctor with right dimensions
-	template <class T> struct get {
-	   	static inline T ctor( std::array<size_t,impl::rank<T>::value> dims ){
-			return T(); }};
+		// 6.) ctor with right dimensions
+		template <class T> struct get {
+		static inline T ctor( std::array<size_t,impl::rank<T>::value> ){
+				return T(); }};
 	template<class T>
 	struct get<std::vector<T>> {
 		static inline std::vector<T> ctor( std::array<size_t,1> dims ){

--- a/h5cpp/H5Pdapl.hpp
+++ b/h5cpp/H5Pdapl.hpp
@@ -6,13 +6,15 @@
 
 #define H5CPP_DAPL_HIGH_THROUGHPUT "h5cpp_dapl_highthroughput"
 
-namespace h5::impl {
-	inline herr_t dapl_pipeline_close( const char *name, size_t size, void *ptr ){
-		delete *static_cast< impl::pipeline_t<impl::basic_pipeline_t>**>( ptr );
+	namespace h5::impl {
+		inline herr_t dapl_pipeline_close( const char *name, size_t size, void *ptr ){
+			(void)name; (void)size;
+			delete *static_cast< impl::pipeline_t<impl::basic_pipeline_t>**>( ptr );
 		return 0;
-	}
-	inline ::herr_t dapl_pipeline_set(::hid_t dapl ) {
-		//TODO: see why H5CPP pipeline crashes with 1.12.x  
+		}
+		inline ::herr_t dapl_pipeline_set(::hid_t dapl ) {
+			(void)dapl;
+		//TODO: see why H5CPP pipeline crashes with 1.12.x
 #if H5_VERSION_LE(1,10,6) 
 		// ignore if already set 
 		if( H5Pexist(dapl, H5CPP_DAPL_HIGH_THROUGHPUT) ) return 0;
@@ -58,4 +60,3 @@ namespace h5 {
 	//const static h5::dapl_t default_dapl = high_throughput;
 	inline const h5::dapl_t& default_dapl = impl::_default_dapl_singleton();
 }
-

--- a/h5cpp/H5Rall.hpp
+++ b/h5cpp/H5Rall.hpp
@@ -128,8 +128,7 @@ namespace h5::exp {
 	inline h5::ds_t write( const h5::fd_t& fd, const std::string& dataset_path,  h5::reference_t& reference, 
                 const T* ptr,  args_t&&... args  ) try {
         
-        using tcount  = typename arg::tpos<const h5::count_t&, const args_t&...>;
-		//static_assert( tcount::present, "h5::count_t{ ... } must be provided to describe T* memory region" );
+			//static_assert( tcount::present, "h5::count_t{ ... } must be provided to describe T* memory region" );
 		h5::ds_t ds; // initialized to H5I_UNINIT
 		
 		h5::mute(); // find out if we have to create the dataset 

--- a/h5cpp/H5Sall.hpp
+++ b/h5cpp/H5Sall.hpp
@@ -19,16 +19,16 @@ namespace h5{ namespace impl {
 			for(int i=0; i<rank; i++) data[i] = *(list.begin() + i);
 		}
 		// support linalg objects upto 3 dimensions or cubes
-		template<class A> array( const std::array<A,0> l ) : rank(0), data{} {}
+		template<class A> array( const std::array<A,0> ) : rank(0), data{} {}
 		template<class A> array( const std::array<A,1> l ) : rank(1), data{l[0]} {}
 		template<class A> array( const std::array<A,2> l ) : rank(2), data{l[0],l[1]} {}
 		template<class A> array( const std::array<A,3> l ) : rank(3), data{l[0],l[1],l[2]} {}
 
 		/** @brief computes the total space 
 		 */	
-		explicit operator const hsize_t () const {
+		explicit operator hsize_t () const {
 			hsize_t size = 1; 
-			for(hsize_t i=0; i<rank; i++) size *= data[i];
+			for(int i=0; i<rank; i++) size *= data[i];
 			return size;
 		}
 		// automatic conversion to std::array means to collapse tail dimensions
@@ -64,7 +64,7 @@ namespace h5{ namespace impl {
 		explicit operator array<C>(){
 			array<C> arr;
 			arr.rank = rank;
-			hsize_t i=0;
+			int i=0;
 			for(; i<rank; i++) arr[i] = data[i];
 			// the shape/dimension may be different, be certain the 
 			// remaining is initilized to ones
@@ -172,4 +172,3 @@ namespace h5::impl {
 		return current_dims;
 	}
 }
-

--- a/h5cpp/H5Tmeta.hpp
+++ b/h5cpp/H5Tmeta.hpp
@@ -423,12 +423,12 @@ namespace h5::meta {
         std::enable_if_t<meta::has_size<T>::value, std::array<size_t,1>
         > size(const T& ref){
         return {ref.size()};
-    };
-    template <class T, size_t N>
-        std::array<size_t,1> size(const T(&ref)[N]){ return {N};};
-    template <class T, class... Ts> struct get {
-        static inline T ctor( std::array<size_t,0> dims ){
-            return T(); }};
+	    };
+	    template <class T, size_t N>
+	        std::array<size_t,1> size(const T(&)[N]){ return {N};};
+	    template <class T, class... Ts> struct get {
+	        static inline T ctor( std::array<size_t,0> ){
+	            return T(); }};
     // ARRAYS
 
     //already defined line 58: template <class T, int N> struct rank<T[N]> : public std::rank<T[N]>{};
@@ -450,7 +450,7 @@ namespace h5::meta {
     template <class T,int N6,int N5,int N4,int N3,int N2,int N1,int N0>T* data(T(&ref)[N6][N5][N4][N3][N2][N1][N0]){ return &ref[0][0][0][0][0][0][0];};
 
     template <class T, int N> std::array<size_t, std::rank<T[N]>::value>
-        size(const T* ref ){ return  h5::meta::get_extent<T[N]>(); };
+        size(const T* ){ return  h5::meta::get_extent<T[N]>(); };
    // template <class T, int N> struct get {
    //     static inline T[N] ctor( std::array<size_t,0> dims ){
    //         return T[N](); }};
@@ -470,9 +470,9 @@ namespace h5::meta {
    //     return ref.data();
    // }
     template <class T, class... Ts> std::array<size_t,1> size( const std::basic_string<T, Ts...>& ref ){ return{ref.size()}; }
-    template <class T, class... Ts> struct get<std::basic_string<T,Ts...>> {
-        static inline std::basic_string<T,Ts...> ctor( std::array<size_t,1> dims ){
-            return std::basic_string<T,Ts...>(); }};
+	    template <class T, class... Ts> struct get<std::basic_string<T,Ts...>> {
+	        static inline std::basic_string<T,Ts...> ctor( std::array<size_t,1> ){
+	            return std::basic_string<T,Ts...>(); }};
 
 // STD::INITIALIZER_LIST<T>
     template<int N0> struct rank<std::initializer_list<char[N0]>>: public std::integral_constant<size_t,1>{};
@@ -490,13 +490,13 @@ namespace h5::meta {
     template <class T, size_t N> inline const T* data( const std::array<T,N>& ref ){ return ref.data(); }
     template <class T, size_t N> inline T* data( std::array<T,N>& ref ){ return ref.data(); }
 
-    template <class T, size_t N> inline typename std::array<size_t,1> size( const std::array<T,N>& ref ){ return {N}; }
+	    template <class T, size_t N> inline typename std::array<size_t,1> size( const std::array<T,N>& ){ return {N}; }
     template <class T, size_t N> struct rank<std::array<T,N>> : public std::integral_constant<int,1> {};
 // END STD::ARRAY
 
-    template <class T> void get_fields( T& sp ){}
-    template <class T> void get_field_names( T& sp ){}
-    template <class T> void get_field_attributes( T& sp ){}
+	    template <class T> void get_fields( T& ){}
+	    template <class T> void get_field_names( T& ){}
+	    template <class T> void get_field_attributes( T& ){}
 
 // NON_CONTIGUOUS 
     template <class T> struct member {

--- a/h5cpp/H5Zall.hpp
+++ b/h5cpp/H5Zall.hpp
@@ -49,12 +49,13 @@ namespace h5::impl::filter {
 		htri_t can_apply(::hid_t dcpl, ::hid_t type, ::hid_t space){
 			return static_cast<Derived*>(this)->can_apply_impl(dcpl,type,space);
 		}
-		herr_t set_local(::hid_t dcpl, ::hid_t type, ::hid_t space){
-			return static_cast<Derived*>(this)->set_local_impl(dcpl,type,space);
-		}
-		size_t callback(unsigned int flags, size_t cd_nelmts, const unsigned int cd_values[], size_t nbytes, size_t *buf_size, void **buf){
-			return 0;
-		}
+			herr_t set_local(::hid_t dcpl, ::hid_t type, ::hid_t space){
+				return static_cast<Derived*>(this)->set_local_impl(dcpl,type,space);
+			}
+			size_t callback(unsigned int flags, size_t cd_nelmts, const unsigned int cd_values[], size_t nbytes, size_t *buf_size, void **buf){
+				(void)flags; (void)cd_nelmts; (void)cd_values; (void)nbytes; (void)buf_size; (void)buf;
+				return 0;
+			}
 		size_t apply( void* dst, const void* src, size_t size){
 			return static_cast<Derived*>(this)->apply(dst,src,size);
 		}
@@ -65,11 +66,12 @@ namespace h5::impl::filter {
 		std::string name;
 	};
 
-	using call_t = size_t (*)(void* dst, const void* src, size_t size, unsigned flags, size_t n, const unsigned params[] );
-	inline size_t mock( void* dst, const void* src, size_t size, unsigned flags, size_t n, const unsigned params[] ){
-		memcpy(dst,src,size);
-		return size;
-	}
+		using call_t = size_t (*)(void* dst, const void* src, size_t size, unsigned flags, size_t n, const unsigned params[] );
+		inline size_t mock( void* dst, const void* src, size_t size, unsigned flags, size_t n, const unsigned params[] ){
+			(void)flags; (void)n; (void)params;
+			memcpy(dst,src,size);
+			return size;
+		}
 	inline unsigned compression_level(size_t n, const unsigned params[]) {
 		return n > 0 ? params[0] : H5CPP_DEFAULT_COMPRESSION;
 	}
@@ -146,12 +148,13 @@ namespace h5::impl::filter {
 	// H5Z_FILTER_SCALEOFFSET (id=6): quantised float/int pre-processing.
 	// Intentional passthrough: the HDF5 C library registers and applies this filter
 	// natively during H5Dread/H5Dwrite.  Reimplementing it in H5CPP provides no
-	// throughput benefit for the trading use-case and would introduce maintenance
-	// cost with no measurable gain.  Delegate to HDF5 C.
-	inline size_t scaleoffset( void* dst, const void* src, size_t size, unsigned flags, size_t n, const unsigned params[]){
-		memcpy(dst,src,size);
-		return size;
-	}
+		// throughput benefit for the trading use-case and would introduce maintenance
+		// cost with no measurable gain.  Delegate to HDF5 C.
+		inline size_t scaleoffset( void* dst, const void* src, size_t size, unsigned flags, size_t n, const unsigned params[]){
+			(void)flags; (void)n; (void)params;
+			memcpy(dst,src,size);
+			return size;
+		}
 
 	// Byte-level shuffle / unshuffle.
 	// Matching HDF5 H5Z_FILTER_SHUFFLE semantics: for n elements of `type_size` bytes
@@ -203,9 +206,10 @@ namespace h5::impl::filter {
 
 	// Fletcher32 checksum filter.
 	// Encode: appends a 4-byte big-endian checksum → returns size + 4.
-	// Decode: verifies, strips 4-byte checksum → returns size - 4, or 0 on mismatch.
-	inline size_t fletcher32( void* dst, const void* src, size_t size, unsigned flags, size_t n, const unsigned params[]){
-		if (flags & H5Z_FLAG_REVERSE) {
+		// Decode: verifies, strips 4-byte checksum → returns size - 4, or 0 on mismatch.
+		inline size_t fletcher32( void* dst, const void* src, size_t size, unsigned flags, size_t n, const unsigned params[]){
+			(void)n; (void)params;
+			if (flags & H5Z_FLAG_REVERSE) {
 			if (size < 4) return 0;
 			const size_t data_size = size - 4;
 			const uint8_t* stored_bytes = static_cast<const uint8_t*>(src) + data_size;
@@ -236,11 +240,12 @@ namespace h5::impl::filter {
 	// HDF5 cd_values layout (from H5Zszip.c):
 	//   params[0] = options_mask   (SZ_EC_OPTION_MASK | SZ_NN_OPTION_MASK | SZ_MSB/LSB | ...)
 	//   params[1] = bits_per_pixel (element size in bits, 1..24 or 32/64)
-	//   params[2] = pixels_per_block (2..32, must be even)
-	//   params[3] = pixels_per_scanline (= total elements in chunk)
-	inline size_t szip( void* dst, const void* src, size_t size, unsigned flags, size_t n, const unsigned params[]){
+		//   params[2] = pixels_per_block (2..32, must be even)
+		//   params[3] = pixels_per_scanline (= total elements in chunk)
+		inline size_t szip( void* dst, const void* src, size_t size, unsigned flags, size_t n, const unsigned params[]){
+			(void)flags; (void)n; (void)params;
 #if defined(H5CPP_HAS_SZIP)
-		if (n < 4) return 0;
+			if (n < 4) return 0;
 
 		SZ_com_t param;
 		param.options_mask       = static_cast<int>(params[0]);
@@ -273,30 +278,35 @@ namespace h5::impl::filter {
 	// Intentional passthrough: the HDF5 C library registers and applies this filter
 	// natively during H5Dread/H5Dwrite.  Reimplementing it in H5CPP provides no
 	// throughput benefit for the trading use-case (integer sensor data compression
-	// is not on the critical path) and would require reverse-engineering HDF5's
-	// internal cd_values descriptor format.  Delegate to HDF5 C.
-	inline size_t nbit( void* dst, const void* src, size_t size, unsigned flags, size_t n, const unsigned params[]){
-		memcpy(dst,src,size);
-		return size;
-	}
-	inline size_t add( void* dst, const void* src, size_t size, unsigned flags, size_t n, const unsigned params[] ){
-		memcpy(dst,src,size);
-		return size;
-	}
-	inline size_t jpeg( void* dst, const void* src, size_t size, unsigned flags, size_t n, const unsigned params[] ){
-		memcpy(dst,src,size);
-		return size;
-	}
-	inline size_t disperse( void* dst, const void* src, size_t size, unsigned flags, size_t n, const unsigned params[] ){
-		memcpy(dst,src,size);
-		return size;
-	}
+		// is not on the critical path) and would require reverse-engineering HDF5's
+		// internal cd_values descriptor format.  Delegate to HDF5 C.
+		inline size_t nbit( void* dst, const void* src, size_t size, unsigned flags, size_t n, const unsigned params[]){
+			(void)flags; (void)n; (void)params;
+			memcpy(dst,src,size);
+			return size;
+		}
+		inline size_t add( void* dst, const void* src, size_t size, unsigned flags, size_t n, const unsigned params[] ){
+			(void)flags; (void)n; (void)params;
+			memcpy(dst,src,size);
+			return size;
+		}
+		inline size_t jpeg( void* dst, const void* src, size_t size, unsigned flags, size_t n, const unsigned params[] ){
+			(void)flags; (void)n; (void)params;
+			memcpy(dst,src,size);
+			return size;
+		}
+		inline size_t disperse( void* dst, const void* src, size_t size, unsigned flags, size_t n, const unsigned params[] ){
+			(void)flags; (void)n; (void)params;
+			memcpy(dst,src,size);
+			return size;
+		}
 
-	// LZ4 extreme-throughput compression (community filter ID 32004).
-	// Enabled when compiled with H5CPP_HAS_LZ4; falls back to passthrough otherwise.
-	inline size_t lz4( void* dst, const void* src, size_t size, unsigned flags, size_t n, const unsigned params[] ){
+		// LZ4 extreme-throughput compression (community filter ID 32004).
+		// Enabled when compiled with H5CPP_HAS_LZ4; falls back to passthrough otherwise.
+		inline size_t lz4( void* dst, const void* src, size_t size, unsigned flags, size_t n, const unsigned params[] ){
+			(void)flags; (void)n; (void)params;
 #if defined(H5CPP_HAS_LZ4)
-		if (flags & H5Z_FLAG_REVERSE) {
+			if (flags & H5Z_FLAG_REVERSE) {
 			const int out = LZ4_decompress_safe(
 				static_cast<const char*>(src), static_cast<char*>(dst),
 				static_cast<int>(size),
@@ -314,11 +324,12 @@ namespace h5::impl::filter {
 #endif
 	}
 
-	// Zstd compression (community filter ID 32015).
-	// Enabled when compiled with H5CPP_HAS_ZSTD; falls back to passthrough otherwise.
-	inline size_t zstd( void* dst, const void* src, size_t size, unsigned flags, size_t n, const unsigned params[] ){
+		// Zstd compression (community filter ID 32015).
+		// Enabled when compiled with H5CPP_HAS_ZSTD; falls back to passthrough otherwise.
+		inline size_t zstd( void* dst, const void* src, size_t size, unsigned flags, size_t n, const unsigned params[] ){
+			(void)flags; (void)n; (void)params;
 #if defined(H5CPP_HAS_ZSTD)
-		if (flags & H5Z_FLAG_REVERSE) {
+			if (flags & H5Z_FLAG_REVERSE) {
 			const size_t out = ZSTD_decompress(
 				dst, decompressed_size_hint(size, n, params), src, size);
 			return ZSTD_isError(out) ? 0 : out;
@@ -334,9 +345,10 @@ namespace h5::impl::filter {
 #endif
 	}
 
-	inline size_t error( void* dst, const void* src, size_t size, unsigned flags, size_t n, const unsigned params[] ){
-		throw std::runtime_error("invalid filter");
-		return size;
+		inline size_t error( void* dst, const void* src, size_t size, unsigned flags, size_t n, const unsigned params[] ){
+			(void)dst; (void)src; (void)flags; (void)n; (void)params;
+			throw std::runtime_error("invalid filter");
+			return size;
 	}
 	inline call_t get_callback( H5Z_filter_t filter_id ){
 

--- a/h5cpp/H5Zpipeline.hpp
+++ b/h5cpp/H5Zpipeline.hpp
@@ -129,46 +129,54 @@ namespace h5{ namespace impl {
 		void write_chunk_impl( const hsize_t* offset, size_t nbytes, const void* ptr );
 		void read_chunk_impl( const hsize_t* offset, size_t nbytes, void* ptr );
 	};
-	struct threaded_pipeline_t : public pipeline_t<threaded_pipeline_t>{
-		void write_chunk_impl( const hsize_t* offset, size_t nbytes, const void* ptr ){
-		}
-		void read_chunk_impl( const hsize_t* offset, size_t nbytes, void* ptr ){
-		}
-	};
-	struct romio_pipeline_t : public pipeline_t<romio_pipeline_t>{
-		void write_chunk_impl( const hsize_t* offset, size_t nbytes, const void* ptr ){
-		}
-		void read_chunk_impl( const hsize_t* offset, size_t nbytes, void* ptr ){
-		}
-	};
-	struct hadoop_pipeline_t : public pipeline_t<hadoop_pipeline_t>{
-		void write_chunk_impl( const hsize_t* offset, size_t nbytes, const void* ptr ){
-		}
-		void read_chunk_impl( const hsize_t* offset, size_t nbytes, void* ptr ){
-		}
-	};
+		struct threaded_pipeline_t : public pipeline_t<threaded_pipeline_t>{
+			void write_chunk_impl( const hsize_t* offset, size_t nbytes, const void* ptr ){
+				(void)offset; (void)nbytes; (void)ptr;
+			}
+			void read_chunk_impl( const hsize_t* offset, size_t nbytes, void* ptr ){
+				(void)offset; (void)nbytes; (void)ptr;
+			}
+		};
+		struct romio_pipeline_t : public pipeline_t<romio_pipeline_t>{
+			void write_chunk_impl( const hsize_t* offset, size_t nbytes, const void* ptr ){
+				(void)offset; (void)nbytes; (void)ptr;
+			}
+			void read_chunk_impl( const hsize_t* offset, size_t nbytes, void* ptr ){
+				(void)offset; (void)nbytes; (void)ptr;
+			}
+		};
+		struct hadoop_pipeline_t : public pipeline_t<hadoop_pipeline_t>{
+			void write_chunk_impl( const hsize_t* offset, size_t nbytes, const void* ptr ){
+				(void)offset; (void)nbytes; (void)ptr;
+			}
+			void read_chunk_impl( const hsize_t* offset, size_t nbytes, void* ptr ){
+				(void)offset; (void)nbytes; (void)ptr;
+			}
+		};
 }}
 
 template< class Derived>
-inline void h5::impl::pipeline_t<Derived>::write(
-		const h5::ds_t& ds, const h5::offset_t& offset, const h5::stride_t& stride, const h5::block_t& block, const h5::count_t& count,
-				const h5::dxpl_t& dxpl, const void* ptr){
+	inline void h5::impl::pipeline_t<Derived>::write(
+			const h5::ds_t& ds, const h5::offset_t& offset, const h5::stride_t& stride, const h5::block_t& block, const h5::count_t& count,
+					const h5::dxpl_t& dxpl, const void* ptr){
 
-	h5::offset_t offset_; h5::count_t count_;
-	for(int i=0; i<rank; i++)
-		offset_[i] = offset[i], count_[i] = count[i] * block[i];
+		(void)stride;
+		h5::offset_t offset_; h5::count_t count_;
+		for(hsize_t i=0; i<rank; i++)
+			offset_[i] = offset[i], count_[i] = count[i] * block[i];
 	this->dxpl = dxpl; this->ds = ds;
 	split_to_chunk_write(filter_direction_t::forward, offset_.begin(), count_.begin(), ptr );
 }
 
 template< class Derived>
-inline void h5::impl::pipeline_t<Derived>::read(
-		const h5::ds_t& ds, const h5::offset_t& offset, const h5::stride_t& stride, const h5::block_t& block, const h5::count_t& count,
-				const h5::dxpl_t& dxpl, void* ptr){
+	inline void h5::impl::pipeline_t<Derived>::read(
+			const h5::ds_t& ds, const h5::offset_t& offset, const h5::stride_t& stride, const h5::block_t& block, const h5::count_t& count,
+					const h5::dxpl_t& dxpl, void* ptr){
 
-	h5::offset_t offset_; h5::count_t count_;
-	for(int i=0; i<rank; i++)
-		offset_[i] = offset[i], count_[i] = count[i] * block[i];
+		(void)stride;
+		h5::offset_t offset_; h5::count_t count_;
+		for(hsize_t i=0; i<rank; i++)
+			offset_[i] = offset[i], count_[i] = count[i] * block[i];
 	this->dxpl = dxpl; this->ds = ds;
 	split_to_chunk_read(filter_direction_t::reverse, offset_.begin(), count_.begin(), ptr );
 }
@@ -213,12 +221,13 @@ inline void h5::impl::pipeline_t<Derived>::set_cache( const h5::dcpl_t& dcpl, si
 
 #define h5cpp_outer( idx ) for( j##idx =0; j##idx < n##idx; j##idx += b##idx)
 #define h5cpp_inner( idx ) for( i##idx = j##idx; i##idx < std::min(j##idx+b##idx,n##idx); i##idx++)
-#define h5cpp_def( idx ) hsize_t i##idx=0, j##idx = 0, s##idx=0, n##idx=N[idx], b##idx=B[idx], rx##idx=Rx[idx],  ry##idx=Ry[idx];
+	#define h5cpp_def( idx ) [[maybe_unused]] hsize_t i##idx=0, j##idx = 0, s##idx=0, n##idx=N[idx], b##idx=B[idx], rx##idx=Rx[idx],  ry##idx=Ry[idx];
 
 template< class Derived>
-inline void h5::impl::pipeline_t<Derived>::split_to_chunk_read(
-	filter_direction_t direction, const hsize_t* chunk_offset, const hsize_t* dims, void* ptr_ ){
-	char* ptr = static_cast<char*>( ptr_ );
+	inline void h5::impl::pipeline_t<Derived>::split_to_chunk_read(
+		filter_direction_t direction, const hsize_t* chunk_offset, const hsize_t* dims, void* ptr_ ){
+		(void)direction;
+		char* ptr = static_cast<char*>( ptr_ );
 	// compute edges if any - for the data size
 	// computes R residuals, and sets N dimension in reverse order
 	// when actual data dimensions - current_dims are greater then a chunk, it must be broken into chunk size
@@ -240,7 +249,7 @@ inline void h5::impl::pipeline_t<Derived>::split_to_chunk_read(
 		// the coordinates are in j indices
 		D[0] = j0, D[1]=j1, D[2]=j2, D[3]=j3, D[4]=j4, D[5]=j5, D[6]=j6;
 		//coordinates are reversed in D, invert them:
-		for(int k=0;k<rank; k++ ) C[k] = D[rank-k-1] + chunk_offset[k];
+			for(hsize_t k=0;k<rank; k++ ) C[k] = D[rank-k-1] + chunk_offset[k];
 		// execute filters in reverse direction
 		read_chunk( this->C, this->block_size, this->chunk0 );
 
@@ -258,9 +267,10 @@ inline void h5::impl::pipeline_t<Derived>::split_to_chunk_read(
 }
 
 template< class Derived>
-inline void h5::impl::pipeline_t<Derived>::split_to_chunk_write(
-	filter_direction_t direction, const hsize_t* chunk_offset, const hsize_t* dims, const void* ptr_ ){
-	const char* ptr = static_cast<const char*>( ptr_ ); const hsize_t* O = chunk_offset;
+	inline void h5::impl::pipeline_t<Derived>::split_to_chunk_write(
+		filter_direction_t direction, const hsize_t* chunk_offset, const hsize_t* dims, const void* ptr_ ){
+		(void)direction;
+		const char* ptr = static_cast<const char*>( ptr_ ); const hsize_t* O = chunk_offset;
 	// compute edges if any - for the data size
 	// computes R residuals, and sets N dimension in reverse order
 	// when actual data dimensions - current_dims are greater then a chunk, it must be broken into chunk size
@@ -295,7 +305,7 @@ inline void h5::impl::pipeline_t<Derived>::split_to_chunk_write(
 		// the coordinates are in j indices
 		D[0] = j0, D[1]=j1, D[2]=j2, D[3]=j3, D[4]=j4, D[5]=j5, D[6]=j6;
 		//coordinates are reversed in D, invert them:
-		for(int k=0;k<rank; k++ ) C[k] = D[rank-k-1] + chunk_offset[k];
+			for(hsize_t k=0;k<rank; k++ ) C[k] = D[rank-k-1] + chunk_offset[k];
 
 		// execute filters in direction
 		write_chunk( this->C, this->block_size, this->chunk0 );

--- a/h5cpp/H5Zpipeline_basic.hpp
+++ b/h5cpp/H5Zpipeline_basic.hpp
@@ -18,6 +18,7 @@ inline void h5::impl::basic_pipeline_t::write_chunk_impl( const hsize_t* offset,
 			length = filter[0](out, data, nbytes, flags[0], cd_size[0], cd_values[0] ) ;
 			if( !length )
 				mask = 1 << 0;
+			[[fallthrough]];
 		default: // more than one filter
 			for(hsize_t j=1; j<tail; j++){ // invariant: out == buffer holding final result
 				tmp = in, in = out, out = tmp;
@@ -32,6 +33,7 @@ inline void h5::impl::basic_pipeline_t::write_chunk_impl( const hsize_t* offset,
 
 
 inline void h5::impl::basic_pipeline_t::read_chunk_impl( const hsize_t* offset, size_t nbytes, void* data){
+	(void)data;
 	size_t length = nbytes;
 	uint32_t filter_mask;
 
@@ -67,4 +69,3 @@ inline void h5::impl::basic_pipeline_t::read_chunk_impl( const hsize_t* offset, 
 	}
 	// src now points to chunk0, which holds the decompressed chunk data
 }
-

--- a/h5cpp/H5capi.hpp
+++ b/h5cpp/H5capi.hpp
@@ -98,7 +98,7 @@ namespace h5 {
 	template<class T>
 	inline size_t get_size( const h5::dt_t<T>& type ){
 		size_t size;
-		H5CPP_CHECK_NZ( (size =  H5Tget_size( static_cast<hid_t>(type) )), std::runtime_error, h5::error::msg::get_filetype_size );
+		H5CPP_CHECK_SIZE( (size =  H5Tget_size( static_cast<hid_t>(type) )), std::runtime_error, h5::error::msg::get_filetype_size );
 		return size;
 	}
 

--- a/h5cpp/H5config.hpp
+++ b/h5cpp/H5config.hpp
@@ -63,6 +63,7 @@
 
 #define H5CPP_CHECK_EQ( call, exception, msg ) if( call == 0 ) throw exception( H5CPP_ERROR_MSG( msg ));
 #define H5CPP_CHECK_NZ( call, exception, msg ) if( call < 0 ) throw exception( H5CPP_ERROR_MSG( msg ));
+#define H5CPP_CHECK_SIZE( call, exception, msg ) if( call == 0 ) throw exception( H5CPP_ERROR_MSG( msg ));
 #define H5CPP_CHECK_NULL( call, exception, msg ) if( call == nullptr ) throw exception( H5CPP_ERROR_MSG( msg ));
 #define H5CPP_CHECK_PROP( id, exception, msg ) if( static_cast<::hid_t>( id ) < 0 ) throw exception( H5CPP_ERROR_MSG( msg ));
 #define H5CPP_CHECK_ID( id, exception, msg ) if( !static_cast<::hid_t>( id ) ) throw exception( H5CPP_ERROR_MSG( msg ));
@@ -162,4 +163,3 @@
  *  **off** and **on**.  Typically used when failure is information: checking existence of [dataset|path] by call-fail pattern, etc...  
  *  \hdf5_links
  */
-

--- a/test/H5Zdeflate.cpp
+++ b/test/H5Zdeflate.cpp
@@ -78,8 +78,7 @@ TEST_CASE("H5Z deflate callback decodes with only level param (external-file com
     // libdeflate.  The pipeline fix in set_cache prevents this by injecting block_size into
     // params[1].  This test covers the callback layer; pipeline-level coverage is in
     // the set_cache path exercised by H5Dio tests.
-    const unsigned dec_params_no_hint[] = {6};
-    std::vector<unsigned char> decoded(input.size());
+	    std::vector<unsigned char> decoded(input.size());
     // With zlib fallback uncompress() ignores max output size — always succeeds.
     // With libdeflate we need the correct output size; the set_cache fix provides it.
     // Here we simulate the fixed pipeline: params[1] = block_size is injected.

--- a/test/H5Zlz4.cpp
+++ b/test/H5Zlz4.cpp
@@ -20,7 +20,7 @@ TEST_CASE("lz4: library availability check") {
     CHECK(true);
     MESSAGE("LZ4 is active");
 #else
-    WARN("LZ4 not configured; filter falls back to passthrough");
+    WARN_MESSAGE(false, "LZ4 not configured; filter falls back to passthrough");
 #endif
 }
 

--- a/test/H5Zszip.cpp
+++ b/test/H5Zszip.cpp
@@ -21,7 +21,7 @@ TEST_CASE("szip: library availability check") {
     CHECK(true);
     MESSAGE("SZIP is active (vendored v2.2.0)");
 #else
-    WARN("SZIP not configured; filter falls back to passthrough");
+    WARN_MESSAGE(false, "SZIP not configured; filter falls back to passthrough");
 #endif
 }
 

--- a/test/H5Zzstd.cpp
+++ b/test/H5Zzstd.cpp
@@ -20,7 +20,7 @@ TEST_CASE("zstd: library availability check") {
     CHECK(true);
     MESSAGE("Zstd is active");
 #else
-    WARN("Zstd not configured (install libzstd-dev); filter falls back to passthrough");
+    WARN_MESSAGE(false, "Zstd not configured (install libzstd-dev); filter falls back to passthrough");
 #endif
 }
 

--- a/test/examples/test_blitz_io.cpp
+++ b/test/examples/test_blitz_io.cpp
@@ -41,7 +41,7 @@ TEST_CASE("[example] blitz Array round-trip") {
 
     // BUILD and WRITE vector
     Vector V(4);
-    for (int i = 0; i < V.size(); ++i)
+    for (blitz::sizeType i = 0; i < V.size(); ++i)
         V(i) = static_cast<double>(i * 2);
 
     {
@@ -55,7 +55,7 @@ TEST_CASE("[example] blitz Array round-trip") {
         auto readback = h5::read<Vector>(fd, "vector");
 
         CHECK(readback.size() == V.size());
-        for (int i = 0; i < V.size(); ++i) {
+        for (blitz::sizeType i = 0; i < V.size(); ++i) {
             CHECK(readback(i) == doctest::Approx(V(i)));
         }
     }

--- a/test/examples/test_csv_io.cpp
+++ b/test/examples/test_csv_io.cpp
@@ -19,7 +19,8 @@ TEST_CASE("[example] compound struct CSV-like round-trip") {
     std::filesystem::remove(filename);
     auto set_location = [](char (&dst)[STR_ARRAY_SIZE], const char* src) {
         std::memset(dst, 0, STR_ARRAY_SIZE);
-        std::strncpy(dst, src, STR_ARRAY_SIZE - 1);
+        const auto src_size = std::strlen(src);
+        std::memcpy(dst, src, src_size < STR_ARRAY_SIZE ? src_size : STR_ARRAY_SIZE - 1);
     };
 
     // BUILD test data (simulating parsed CSV rows)

--- a/test/examples/test_csv_io.cpp
+++ b/test/examples/test_csv_io.cpp
@@ -17,15 +17,19 @@
 TEST_CASE("[example] compound struct CSV-like round-trip") {
     const char* filename = "test_csv_io.h5";
     std::filesystem::remove(filename);
+    auto set_location = [](char (&dst)[STR_ARRAY_SIZE], const char* src) {
+        std::memset(dst, 0, STR_ARRAY_SIZE);
+        std::strncpy(dst, src, STR_ARRAY_SIZE - 1);
+    };
 
     // BUILD test data (simulating parsed CSV rows)
     std::vector<input_t> original(3);
     original[0] = input_t{902363382, 0, 39.15920668, -86.52587356, {}};
-    std::strncpy(original[0].ReportedLocation, "1ST & FESS", STR_ARRAY_SIZE);
+    set_location(original[0].ReportedLocation, "1ST & FESS");
     original[1] = input_t{902364268, 1500, 39.16144, -86.534848, {}};
-    std::strncpy(original[1].ReportedLocation, "2ND & COLLEGE", STR_ARRAY_SIZE);
+    set_location(original[1].ReportedLocation, "2ND & COLLEGE");
     original[2] = input_t{902364412, 2300, 39.14978027, -86.56889006, {}};
-    std::strncpy(original[2].ReportedLocation, "BASSWOOD & BLOOMFIELD", STR_ARRAY_SIZE);
+    set_location(original[2].ReportedLocation, "BASSWOOD & BLOOMFIELD");
 
     // WRITE using packet table append (same pattern as csv example)
     {

--- a/test/win_stack_probe.cpp
+++ b/test/win_stack_probe.cpp
@@ -17,13 +17,13 @@
 #include <h5cpp/io>
 
 namespace {
-    char* g_sp_top = nullptr;
+    std::uintptr_t g_sp_top = 0;
 
     inline std::ptrdiff_t stack_used() {
         volatile char marker;
-        char* sp = const_cast<char*>(&marker);
-        if (g_sp_top == nullptr || sp > g_sp_top) g_sp_top = sp;
-        return g_sp_top - sp;
+        std::uintptr_t sp = reinterpret_cast<std::uintptr_t>(const_cast<char*>(&marker));
+        if (g_sp_top == 0 || sp > g_sp_top) g_sp_top = sp;
+        return static_cast<std::ptrdiff_t>(g_sp_top - sp);
     }
 
     void probe(const char* label) {


### PR DESCRIPTION
## Summary

- Fix semantic warning findings from the compile-warning audit: `H5Tget_size()` zero-on-error handling, the `H5Dcreate.hpp` temporary default lifetime, and the intentional pipeline fallthrough annotation.
- Silence core-header `-Wall -Wextra` warnings from unused API parameters, unused local typedefs/variables, and signed comparisons without changing public behavior.
- Clean up test/example warning sites exposed by the full test build.

## Validation

- `cmake -S . -B build-werror -DCMAKE_CXX_FLAGS="-Wall -Wextra -Werror" -DCMAKE_BUILD_TYPE=Debug -DH5CPP_BUILD_TESTS=ON`
- `cmake --build build-werror -j2`
- `ctest --test-dir build-werror --output-on-failure`
- `git diff --check`

All 34 CTest tests passed locally.
