### PR TITLE
[#176]:svarga:ci, bump GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
           set -euxo pipefail
 
           brew update
-          brew install cmake ninja hdf5
+          brew install --quiet cmake ninja hdf5
 
           HDF5_PREFIX="$(brew --prefix hdf5)"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -195,7 +195,7 @@ jobs:
       - name: Restore HDF5 1.10.10 cache
         if: runner.os == 'Windows'
         id: cache-hdf5
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ${{ runner.temp }}\hdf5-${{ env.HDF5_VERSION }}-install
           key: hdf5-${{ runner.os }}-${{ matrix.compiler }}-${{ env.HDF5_VERSION }}-${{ env.HDF5_CACHE_VERSION }}
@@ -241,7 +241,7 @@ jobs:
 
       - name: Save HDF5 1.10.10 cache
         if: runner.os == 'Windows' && steps.cache-hdf5.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: ${{ runner.temp }}\hdf5-${{ env.HDF5_VERSION }}-install
           key: ${{ steps.cache-hdf5.outputs.cache-primary-key }}
@@ -339,7 +339,7 @@ jobs:
 
       - name: Upload Status Artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: status-${{ matrix.os }}-${{ matrix.compiler }}
           path: badge-status/status-${{ matrix.os }}-${{ matrix.compiler }}.json
@@ -359,7 +359,7 @@ jobs:
           sudo apt-get install -y jq curl
 
       - name: Download all status artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: badge-status
           pattern: status-*
@@ -430,7 +430,7 @@ jobs:
 
       - name: Upload badges artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ github.ref_name == 'staging' && 'badges-staging' || 'badges' }}
           path: ${{ github.ref_name == 'staging' && 'badges-staging' || 'badges' }}
@@ -456,7 +456,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -530,7 +530,7 @@ jobs:
           lcov --gcov-tool /usr/bin/gcov-14 --list coverage.info
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           files: ./coverage.info
           disable_search: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
 


### PR DESCRIPTION
Fixes #176

Bumps all GitHub Actions to Node.js 24 compatible versions ahead of GitHub's June 2 forced migration deadline.

| Action | From | To |
|---|---|---|
| `actions/checkout` | `v4` | `v6` |
| `actions/cache/restore` | `v4` | `v5` |
| `actions/cache/save` | `v4` | `v5` |
| `actions/upload-artifact` | `v4` | `v7` |
| `actions/download-artifact` | `v4` | `v8` |
| `codecov/codecov-action` | `v5` | `v6` |
| `actions/setup-python` | `v5` | `v6` (docs.yml) |

`peaceiris/actions-gh-pages@v4` unchanged — v4.1.0 (2026-05-12) is already the Node.js 24 release.

`upload-artifact@v7` and `download-artifact@v8` are the current compatible pair for the same artifact storage format.