### PR TITLE
[#89]:svarga:refactor, dataset I/O new type engine with access_traits_t dispatch

### DIFF
--- a/h5cpp/H5Dwrite.hpp
+++ b/h5cpp/H5Dwrite.hpp
@@ -193,25 +193,44 @@ namespace h5 {
 		using tcount = typename arg::tpos<const h5::count_t&,const args_t&...>;
 		using element_t = typename impl::decay<T>::type;
 
-		if constexpr (h5::meta::is_contiguous<T>::value) { // arrays/vectors/matrices of pod_t, funcamental types, but NOT vector<std::string> ... etc
-			auto ptr = h5::impl::data(ref);
-			if constexpr (tcount::present) // explicitly set: mem_space and file_space are given
+		using traits = h5::meta::access_traits_t<T>;
+		constexpr auto kind = traits::kind;
+
+		if constexpr (kind == h5::meta::access_t::contiguous
+				   || kind == h5::meta::access_t::object
+				   || kind == h5::meta::access_t::text) {
+			auto ptr = traits::data(ref);
+			if constexpr (tcount::present)
 				::h5::write(ds, ptr,  args...);
-			else { // we have to find out the size of `ref` and compute h5::count{}	
-				h5::count_t count = impl::size( ref );
+			else {
+				h5::count_t count = traits::size( ref );
 				::h5::write(ds, ptr, count, args...);
 			}
-		} else { // variable length datasets: ragged arrays, vector of strings...
-			// SUBTLE: lowering element_t type here with one level 
-			using element_t = typename impl::decay<element_t>::type;
+		} else if constexpr (kind == h5::meta::access_t::pointers) {
+			// e.g. vector<string>, vector<vector<int>> — elements have .data() but are not flat
+			using element_t = typename impl::decay<typename traits::element_t>::type;
 			std::vector<element_t> elements;
 			const element_t* ptrs = h5::gather(ref, elements);
-			if constexpr (tcount::present) // explicitly set: mem_space and file_space are given
+			if constexpr (tcount::present)
 				::h5::write<element_t>(ds, ptrs,  args...);
-			else { // we have to find out the size of `ref` and compute h5::count{}	
-				h5::count_t count = impl::size( ref );
+			else {
+				h5::count_t count = traits::size( ref );
 				::h5::write<element_t>(ds, ptrs, count, args...);
 			}
+		} else if constexpr (kind == h5::meta::access_t::iterators) {
+			// e.g. list<int>, set<int>, map<K,V> — no direct pointer, copy to staging buffer
+			using element_t = typename impl::decay<typename traits::element_t>::type;
+			auto count = traits::size(ref);
+			size_t n = 1;
+			for (std::size_t i = 0; i < count.size(); ++i) n *= count[i];
+			std::vector<element_t> buffer;
+			buffer.reserve(n);
+			for (const auto& elem : ref)
+				buffer.push_back(elem);
+			::h5::write(ds, buffer.data(), h5::count_t(count), args...);
+		} else {
+			static_assert(kind != h5::meta::access_t::unsupported,
+				"unsupported type for h5::write");
 		}
 		return ds;
 	} catch ( const std::exception& err ){

--- a/h5cpp/H5Marma.hpp
+++ b/h5cpp/H5Marma.hpp
@@ -30,6 +30,13 @@ namespace h5::meta {
 namespace h5::impl {
 	// 1.) object -> H5T_xxx
 
+	// Register Armadillo types so the structural decay fallback in H5Mstl.hpp
+	// does not create an ambiguous partial-specialisation with these explicit specs.
+	template <class T> struct detail::has_explicit_decay<h5::arma::rowvec<T>> : std::true_type {};
+	template <class T> struct detail::has_explicit_decay<h5::arma::colvec<T>> : std::true_type {};
+	template <class T> struct detail::has_explicit_decay<h5::arma::colmat<T>> : std::true_type {};
+	template <class T> struct detail::has_explicit_decay<h5::arma::cube<T>>   : std::true_type {};
+
 	template <class T> struct decay<h5::arma::rowvec<T>>{ using type = T; };
 	template <class T> struct decay<h5::arma::colvec<T>>{ using type = T; };
 	template <class T> struct decay<h5::arma::colmat<T>>{ using type = T; };

--- a/h5cpp/H5Marma.hpp
+++ b/h5cpp/H5Marma.hpp
@@ -24,8 +24,13 @@ namespace h5::meta {
     template <class T> struct is_contiguous<h5::arma::colvec<T>> : std::true_type {};
     template <class T> struct is_contiguous<h5::arma::colmat<T>> : std::true_type {};
     template <class T> struct is_contiguous<h5::arma::cube<T>> : std::true_type {};
-}
 
+    // Register types so generic access_traits_t fallbacks don't create ambiguous partial specializations
+    template <class T> struct detail::has_explicit_access_traits<h5::arma::rowvec<T>> : std::true_type {};
+    template <class T> struct detail::has_explicit_access_traits<h5::arma::colvec<T>> : std::true_type {};
+    template <class T> struct detail::has_explicit_access_traits<h5::arma::colmat<T>> : std::true_type {};
+    template <class T> struct detail::has_explicit_access_traits<h5::arma::cube<T>> : std::true_type {};
+}
 
 namespace h5::impl {
 	// 1.) object -> H5T_xxx
@@ -85,5 +90,56 @@ namespace h5::impl {
 		static inline h5::arma::colmat<T> ctor( std::array<size_t,3> dims ){
 			return h5::arma::colmat<T>( dims[2], dims[0], dims[1] );
 	}};
+}
+
+namespace h5::meta {
+    template <class T> struct access_traits_t<h5::arma::rowvec<T>> {
+        using element_t = T;
+        static constexpr access_t kind = access_t::contiguous;
+        static constexpr bool is_trivially_packable = true;
+        static auto data(const h5::arma::rowvec<T>& c) noexcept { return h5::impl::data(c); }
+        static auto size(const h5::arma::rowvec<T>& c) noexcept { return h5::impl::size(c); }
+        static std::size_t bytes(const h5::arma::rowvec<T>& c) noexcept {
+            auto s = size(c); std::size_t n = 1;
+            for (std::size_t i = 0; i < s.size(); ++i) n *= s[i];
+            return n * sizeof(element_t);
+        }
+    };
+    template <class T> struct access_traits_t<h5::arma::colvec<T>> {
+        using element_t = T;
+        static constexpr access_t kind = access_t::contiguous;
+        static constexpr bool is_trivially_packable = true;
+        static auto data(const h5::arma::colvec<T>& c) noexcept { return h5::impl::data(c); }
+        static auto size(const h5::arma::colvec<T>& c) noexcept { return h5::impl::size(c); }
+        static std::size_t bytes(const h5::arma::colvec<T>& c) noexcept {
+            auto s = size(c); std::size_t n = 1;
+            for (std::size_t i = 0; i < s.size(); ++i) n *= s[i];
+            return n * sizeof(element_t);
+        }
+    };
+    template <class T> struct access_traits_t<h5::arma::colmat<T>> {
+        using element_t = T;
+        static constexpr access_t kind = access_t::contiguous;
+        static constexpr bool is_trivially_packable = true;
+        static auto data(const h5::arma::colmat<T>& c) noexcept { return h5::impl::data(c); }
+        static auto size(const h5::arma::colmat<T>& c) noexcept { return h5::impl::size(c); }
+        static std::size_t bytes(const h5::arma::colmat<T>& c) noexcept {
+            auto s = size(c); std::size_t n = 1;
+            for (std::size_t i = 0; i < s.size(); ++i) n *= s[i];
+            return n * sizeof(element_t);
+        }
+    };
+    template <class T> struct access_traits_t<h5::arma::cube<T>> {
+        using element_t = T;
+        static constexpr access_t kind = access_t::contiguous;
+        static constexpr bool is_trivially_packable = true;
+        static auto data(const h5::arma::cube<T>& c) noexcept { return h5::impl::data(c); }
+        static auto size(const h5::arma::cube<T>& c) noexcept { return h5::impl::size(c); }
+        static std::size_t bytes(const h5::arma::cube<T>& c) noexcept {
+            auto s = size(c); std::size_t n = 1;
+            for (std::size_t i = 0; i < s.size(); ++i) n *= s[i];
+            return n * sizeof(element_t);
+        }
+    };
 }
 #endif

--- a/h5cpp/H5Mblaze.hpp
+++ b/h5cpp/H5Mblaze.hpp
@@ -22,6 +22,10 @@ namespace h5::meta {
 		template <class T> struct is_contiguous<h5::blaze::colvec<T>> : std::true_type {};
 		template <class T> struct is_contiguous<h5::blaze::rowmat<T>> : std::true_type {};
 		template <class T> struct is_contiguous<h5::blaze::colmat<T>> : std::true_type {};
+
+		// Register types so generic access_traits_t fallbacks don't create ambiguous partial specializations
+		template <class T> struct detail::has_explicit_access_traits<h5::blaze::rowmat<T>> : std::true_type {};
+		template <class T> struct detail::has_explicit_access_traits<h5::blaze::colmat<T>> : std::true_type {};
 }
 
 namespace h5::impl {
@@ -77,6 +81,33 @@ namespace h5::impl {
 		static inline h5::blaze::colmat<T> ctor( std::array<size_t,2> dims ){
 			return h5::blaze::colmat<T>( dims[0], dims[1] );
 	}};
+}
+
+namespace h5::meta {
+		template <class T> struct access_traits_t<h5::blaze::rowmat<T>> {
+			using element_t = T;
+			static constexpr access_t kind = access_t::contiguous;
+			static constexpr bool is_trivially_packable = true;
+			static auto data(const h5::blaze::rowmat<T>& c) noexcept { return h5::impl::data(c); }
+			static auto size(const h5::blaze::rowmat<T>& c) noexcept { return h5::impl::size(c); }
+			static std::size_t bytes(const h5::blaze::rowmat<T>& c) noexcept {
+				auto s = size(c); std::size_t n = 1;
+				for (std::size_t i = 0; i < s.size(); ++i) n *= s[i];
+				return n * sizeof(element_t);
+			}
+		};
+		template <class T> struct access_traits_t<h5::blaze::colmat<T>> {
+			using element_t = T;
+			static constexpr access_t kind = access_t::contiguous;
+			static constexpr bool is_trivially_packable = true;
+			static auto data(const h5::blaze::colmat<T>& c) noexcept { return h5::impl::data(c); }
+			static auto size(const h5::blaze::colmat<T>& c) noexcept { return h5::impl::size(c); }
+			static std::size_t bytes(const h5::blaze::colmat<T>& c) noexcept {
+				auto s = size(c); std::size_t n = 1;
+				for (std::size_t i = 0; i < s.size(); ++i) n *= s[i];
+				return n * sizeof(element_t);
+			}
+		};
 }
 
 #endif

--- a/h5cpp/H5Mblaze.hpp
+++ b/h5cpp/H5Mblaze.hpp
@@ -26,6 +26,12 @@ namespace h5::meta {
 
 namespace h5::impl {
 	// 1.) object -> H5T_xxx
+	// Register Blaze types in has_explicit_decay (Blaze vectors/matrices have value_type).
+	template <class T> struct detail::has_explicit_decay<h5::blaze::rowvec<T>> : std::true_type {};
+	template <class T> struct detail::has_explicit_decay<h5::blaze::colvec<T>> : std::true_type {};
+	template <class T> struct detail::has_explicit_decay<h5::blaze::rowmat<T>> : std::true_type {};
+	template <class T> struct detail::has_explicit_decay<h5::blaze::colmat<T>> : std::true_type {};
+
 	template <class T> struct decay<h5::blaze::rowvec<T>>{ using type = T; };
 	template <class T> struct decay<h5::blaze::colvec<T>>{ using type = T; };
 	template <class T> struct decay<h5::blaze::rowmat<T>>{ using type = T; };

--- a/h5cpp/H5Mblitz.hpp
+++ b/h5cpp/H5Mblitz.hpp
@@ -14,6 +14,9 @@ namespace h5::blitz {
 
 namespace h5::meta {
 		template <class T, int N> struct is_contiguous<h5::blitz::array<T,N>> : std::true_type {};
+
+		// Register types so generic access_traits_t fallbacks don't create ambiguous partial specializations
+		template <class T, int N> struct detail::has_explicit_access_traits<h5::blitz::array<T,N>> : std::true_type {};
 }
 
 namespace h5::impl {
@@ -49,5 +52,20 @@ namespace h5::impl {
 			for(int i=0; i<N; ++i) shape[i] = static_cast<int>(dims[i]);
 			return h5::blitz::array<T,N>(shape);
 	}};
+}
+
+namespace h5::meta {
+		template <class T, int N> struct access_traits_t<h5::blitz::array<T,N>> {
+			using element_t = T;
+			static constexpr access_t kind = access_t::contiguous;
+			static constexpr bool is_trivially_packable = true;
+			static auto data(const h5::blitz::array<T,N>& c) noexcept { return h5::impl::data(c); }
+			static auto size(const h5::blitz::array<T,N>& c) noexcept { return h5::impl::size(c); }
+			static std::size_t bytes(const h5::blitz::array<T,N>& c) noexcept {
+				auto s = size(c); std::size_t n = 1;
+				for (std::size_t i = 0; i < s.size(); ++i) n *= s[i];
+				return n * sizeof(element_t);
+			}
+		};
 }
 #endif

--- a/h5cpp/H5Mblitz.hpp
+++ b/h5cpp/H5Mblitz.hpp
@@ -18,6 +18,7 @@ namespace h5::meta {
 
 namespace h5::impl {
 	// 1.) object -> H5T_xxx
+	template <class T, int N> struct detail::has_explicit_decay<h5::blitz::array<T,N>> : std::true_type {};
 	template <class T, int N> struct decay<h5::blitz::array<T,N>>{ using type = T; };
 
 	// get read access to datastore

--- a/h5cpp/H5Mdlib.hpp
+++ b/h5cpp/H5Mdlib.hpp
@@ -21,6 +21,7 @@ namespace h5::meta {
 
 namespace h5::impl {
 	// 1.) object -> H5T_xxx
+	template <class T> struct detail::has_explicit_decay<h5::dlib::rowmat<T>> : std::true_type {};
 	template <class T> struct decay<h5::dlib::rowmat<T>>{ using type = T; };
 
 	// get read access to datastaore

--- a/h5cpp/H5Mdlib.hpp
+++ b/h5cpp/H5Mdlib.hpp
@@ -17,6 +17,9 @@ namespace h5::dlib {
 }
 namespace h5::meta {
 		template <class T> struct is_contiguous<h5::dlib::rowmat<T>> : std::true_type {};
+
+		// Register types so generic access_traits_t fallbacks don't create ambiguous partial specializations
+		template <class T> struct detail::has_explicit_access_traits<h5::dlib::rowmat<T>> : std::true_type {};
 }
 
 namespace h5::impl {
@@ -51,5 +54,20 @@ namespace h5::impl {
 		static inline h5::dlib::rowmat<T> ctor( std::array<size_t,2> dims ){
 			return h5::dlib::rowmat<T>( dims[1], dims[0] );
 	}};
+}
+
+namespace h5::meta {
+		template <class T> struct access_traits_t<h5::dlib::rowmat<T>> {
+			using element_t = T;
+			static constexpr access_t kind = access_t::contiguous;
+			static constexpr bool is_trivially_packable = true;
+			static auto data(const h5::dlib::rowmat<T>& c) noexcept { return h5::impl::data(c); }
+			static auto size(const h5::dlib::rowmat<T>& c) noexcept { return h5::impl::size(c); }
+			static std::size_t bytes(const h5::dlib::rowmat<T>& c) noexcept {
+				auto s = size(c); std::size_t n = 1;
+				for (std::size_t i = 0; i < s.size(); ++i) n *= s[i];
+				return n * sizeof(element_t);
+			}
+		};
 }
 #endif

--- a/h5cpp/H5Meigen.hpp
+++ b/h5cpp/H5Meigen.hpp
@@ -27,6 +27,14 @@ namespace h5::meta {
 
 namespace h5::impl {
 	// 1.) object -> H5T_xxx
+	// Register Eigen types in has_explicit_decay to prevent ambiguity with the
+	// structural decay fallback (Eigen matrices expose value_type = Scalar).
+	template<class T,int R,int C, int O>
+	struct detail::has_explicit_decay<::Eigen::Matrix<T,R,C,O>> : std::true_type {};
+	template<class T,int R,int C, int O>
+	struct detail::has_explicit_decay<::Eigen::Array<T,R,C,O>>  : std::true_type {};
+
+	// 1.) object -> H5T_xxx
 	template<class T,int R,int C, int O> struct decay<::Eigen::Matrix<T,R,C,O>>{ using type = T; };
 	template<class T,int R,int C, int O> struct decay<::Eigen::Array<T,R,C,O>>{ using type = T; };
 	    

--- a/h5cpp/H5Mitpp.hpp
+++ b/h5cpp/H5Mitpp.hpp
@@ -13,6 +13,9 @@ namespace h5::itpp {
 }
 namespace h5::meta {
 		template <class T> struct is_contiguous<h5::itpp::rowmat<T>> : std::true_type {};
+
+		// Register types so generic access_traits_t fallbacks don't create ambiguous partial specializations
+		template <class T> struct detail::has_explicit_access_traits<h5::itpp::rowmat<T>> : std::true_type {};
 }
 namespace h5::impl {
 	// 1.) object -> H5T_xxx
@@ -38,6 +41,20 @@ namespace h5::impl {
 			return h5::itpp::rowmat<T>( dims[1], dims[0] );
 	}};
 }
+namespace h5::meta {
+		template <class T> struct access_traits_t<h5::itpp::rowmat<T>> {
+			using element_t = T;
+			static constexpr access_t kind = access_t::contiguous;
+			static constexpr bool is_trivially_packable = true;
+			static auto data(const h5::itpp::rowmat<T>& c) noexcept { return h5::impl::data(c); }
+			static auto size(const h5::itpp::rowmat<T>& c) noexcept { return h5::impl::size(c); }
+			static std::size_t bytes(const h5::itpp::rowmat<T>& c) noexcept {
+				auto s = size(c); std::size_t n = 1;
+				for (std::size_t i = 0; i < s.size(); ++i) n *= s[i];
+				return n * sizeof(element_t);
+			}
+		};
+}
 #endif
 
 #if defined(VEC_H) || defined(H5CPP_USE_ITPP_VECTOR)
@@ -48,6 +65,9 @@ namespace h5::itpp {
 }
 namespace h5::meta {
 		template <class T> struct is_contiguous<h5::itpp::rowvec<T>> : std::true_type {};
+
+		// Register types so generic access_traits_t fallbacks don't create ambiguous partial specializations
+		template <class T> struct detail::has_explicit_access_traits<h5::itpp::rowvec<T>> : std::true_type {};
 }
 namespace h5::impl {
 	template <class T> struct detail::has_explicit_decay<h5::itpp::rowvec<T>> : std::true_type {};
@@ -68,5 +88,19 @@ namespace h5::impl {
 		static inline h5::itpp::rowvec<T> ctor( std::array<size_t,1> dims ){
 			return h5::itpp::rowvec<T>( dims[0] );
 	}};
+}
+namespace h5::meta {
+		template <class T> struct access_traits_t<h5::itpp::rowvec<T>> {
+			using element_t = T;
+			static constexpr access_t kind = access_t::contiguous;
+			static constexpr bool is_trivially_packable = true;
+			static auto data(const h5::itpp::rowvec<T>& c) noexcept { return h5::impl::data(c); }
+			static auto size(const h5::itpp::rowvec<T>& c) noexcept { return h5::impl::size(c); }
+			static std::size_t bytes(const h5::itpp::rowvec<T>& c) noexcept {
+				auto s = size(c); std::size_t n = 1;
+				for (std::size_t i = 0; i < s.size(); ++i) n *= s[i];
+				return n * sizeof(element_t);
+			}
+		};
 }
 #endif

--- a/h5cpp/H5Mitpp.hpp
+++ b/h5cpp/H5Mitpp.hpp
@@ -16,6 +16,7 @@ namespace h5::meta {
 }
 namespace h5::impl {
 	// 1.) object -> H5T_xxx
+	template <class T> struct detail::has_explicit_decay<h5::itpp::rowmat<T>> : std::true_type {};
 	template <class T> struct decay<h5::itpp::rowmat<T>>{ using type = T; };
 
 	// get read access to datastaore
@@ -49,6 +50,7 @@ namespace h5::meta {
 		template <class T> struct is_contiguous<h5::itpp::rowvec<T>> : std::true_type {};
 }
 namespace h5::impl {
+	template <class T> struct detail::has_explicit_decay<h5::itpp::rowvec<T>> : std::true_type {};
 	template <class T> struct decay<h5::itpp::rowvec<T>>{ using type = T; };
 	template <class Object, class T = typename impl::decay<Object>::type> inline
 	std::enable_if_t< h5::itpp::is_supported_v<Object>::value,

--- a/h5cpp/H5Mstl.hpp
+++ b/h5cpp/H5Mstl.hpp
@@ -9,6 +9,7 @@
 #include <array>
 #include <initializer_list>
 #include <type_traits>
+#include "H5meta.hpp"    // for h5::meta::has_size, has_data, is_sequential_like
 
 namespace h5::impl {
 /*STL: */
@@ -17,8 +18,21 @@ namespace h5::impl {
 	// 5.) obtain dimensions of extents
 	// 6.) ctor with right dimensions
 
+	// Helpers to exclude types that have explicit decay specialisations below.
+	// Used by the structural fallback to avoid partial-specialisation ambiguity.
+	namespace detail {
+		template <class T> struct has_explicit_decay : std::false_type {};
+		template <class C, class Tr, class A>
+		struct has_explicit_decay<std::basic_string<C,Tr,A>> : std::true_type {};
+		template <class T, class A>
+		struct has_explicit_decay<std::vector<T,A>> : std::true_type {};
+		template <class T>
+		struct has_explicit_decay<std::initializer_list<T>> : std::true_type {};
+	}
+
 	// 1.) object -> H5T_xxx
-	template <class T, class...> struct decay{ using type = T; };
+	// Primary uses class=void so partial specialisations can use enable_if.
+	template <class T, class = void> struct decay { using type = T; };
 
 	template <class T> struct decay<const T>{ using type = T; };
 	template <class T> struct decay<const T*>{ using type = T*; };
@@ -33,6 +47,23 @@ namespace h5::impl {
 	template <class T> struct decay<std::vector<const T*>>{ using type = const T*; };
 	template <class T> struct decay<std::vector<T*>>{ using type = T*; };
 	template <class T> struct decay<std::vector<T>>{ using type = T; };
+
+	// Gap 2: structural fallback for containers not explicitly registered above.
+	// The enable_if exclusion prevents ambiguity with the explicit specs for
+	// vector, basic_string, and initializer_list (all have value_type too).
+	// Linalg mapper specialisations (H5Marma, H5Meigen, …) are explicit and
+	// must register in detail::has_explicit_decay if they carry value_type.
+	// const/reference/pointer/array variants are handled by the explicit specs
+	// above (decay<const T>, decay<const T*>, decay<T[N]>, etc.).
+	template <class T>
+	struct decay<T, std::enable_if_t<
+		h5::meta::has_value_type<T>::value &&
+		!detail::has_explicit_decay<T>::value &&
+		!std::is_const_v<T> &&
+		!std::is_reference_v<T> &&
+		!std::is_array_v<T> &&
+		!std::is_pointer_v<T>>>
+	{ using type = typename T::value_type; };
 
 	// helpers
 	template <class T>
@@ -64,19 +95,33 @@ namespace h5::impl {
 	// 4.) write access
 	template <class T> inline std::enable_if_t<std::is_integral_v<T>,
 	T*> data( T& ref ){ return &ref; }
-	//template <class T> inline std::enable_if_t<std::is_integral_v<T>,
-	//	const T*> data( const T& ref ){ return &ref; }
-		// 5.) obtain dimensions of extents
-		template <class T> inline constexpr std::enable_if_t< impl::is_scalar<T>::value,
-			std::array<size_t,0>> size( T ){ return{}; }
+	// 5.) obtain dimensions of extents
+	template <class T> inline constexpr std::enable_if_t< impl::is_scalar<T>::value,
+		std::array<size_t,0>> size( T ){ return{}; }
 	template <class T, class A> inline std::array<size_t,1> size( const std::vector<T, A>& ref ){ return {ref.size()}; }
 	template <class T> inline std::array<size_t,1> size( const std::initializer_list<T>& ref ){ return {ref.size()}; }
-	template <class T> inline constexpr std::enable_if_t<!impl::is_scalar<T>::value,
-		std::array<size_t,0>> size( const T& ){ return{}; }
-		// 6.) ctor with right dimensions
-		template <class T> struct get {
-		static inline T ctor( std::array<size_t,impl::rank<T>::value> ){
-				return T(); }};
+	// Gap 2: structural size() — containers with .size() not explicitly covered.
+	// Returns rank-1 extent for any non-scalar with a .size() member.
+	// The explicit vector<T,A> overload above is more specific and wins for vectors.
+	template <class T>
+	inline auto size(const T& ref)
+		-> std::enable_if_t<
+			!impl::is_scalar<T>::value &&
+			h5::meta::has_size<T>::value,
+			std::array<size_t,1>>
+	{ return {ref.size()}; }
+	// Rank-0 fallback for non-scalar types with no .size()
+	template <class T>
+	inline constexpr auto size(const T&)
+		-> std::enable_if_t<
+			!impl::is_scalar<T>::value &&
+			!h5::meta::has_size<T>::value,
+			std::array<size_t,0>>
+	{ return {}; }
+	// 6.) ctor with right dimensions
+	template <class T> struct get {
+	   	static inline T ctor( std::array<size_t,impl::rank<T>::value> ){
+			return T(); }};
 	template<class T>
 	struct get<std::vector<T>> {
 		static inline std::vector<T> ctor( std::array<size_t,1> dims ){

--- a/h5cpp/H5Mublas.hpp
+++ b/h5cpp/H5Mublas.hpp
@@ -16,6 +16,7 @@ namespace h5::meta {
 }
 namespace h5::impl {
 	// 1.) object -> H5T_xxx
+	template <class T> struct detail::has_explicit_decay<h5::ublas::rowmat<T>> : std::true_type {};
 	template <class T> struct decay<h5::ublas::rowmat<T>>{ using type = T; };
 	// get read access to datastaore
 	template <class Object, class T = typename impl::decay<Object>::type> inline
@@ -48,6 +49,7 @@ namespace h5::meta {
 		template <class T> struct is_contiguous<h5::ublas::rowvec<T>> : std::true_type {};
 }
 namespace h5::impl {
+	template <class T> struct detail::has_explicit_decay<h5::ublas::rowvec<T>> : std::true_type {};
 	template <class T> struct decay<h5::ublas::rowvec<T>>{ using type = T; };
 	template <class Object, class T = typename impl::decay<Object>::type> inline
 	std::enable_if_t< h5::ublas::is_supportedv<Object>::value,

--- a/h5cpp/H5Mublas.hpp
+++ b/h5cpp/H5Mublas.hpp
@@ -13,6 +13,9 @@ namespace h5::ublas {
 }
 namespace h5::meta {
 		template <class T> struct is_contiguous<h5::ublas::rowmat<T>> : std::true_type {};
+
+		// Register types so generic access_traits_t fallbacks don't create ambiguous partial specializations
+		template <class T> struct detail::has_explicit_access_traits<h5::ublas::rowmat<T>> : std::true_type {};
 }
 namespace h5::impl {
 	// 1.) object -> H5T_xxx
@@ -37,6 +40,20 @@ namespace h5::impl {
 			return h5::ublas::rowmat<T>( dims[1], dims[0] );
 	}};
 }
+namespace h5::meta {
+		template <class T> struct access_traits_t<h5::ublas::rowmat<T>> {
+			using element_t = T;
+			static constexpr access_t kind = access_t::contiguous;
+			static constexpr bool is_trivially_packable = true;
+			static auto data(const h5::ublas::rowmat<T>& c) noexcept { return h5::impl::data(c); }
+			static auto size(const h5::ublas::rowmat<T>& c) noexcept { return h5::impl::size(c); }
+			static std::size_t bytes(const h5::ublas::rowmat<T>& c) noexcept {
+				auto s = size(c); std::size_t n = 1;
+				for (std::size_t i = 0; i < s.size(); ++i) n *= s[i];
+				return n * sizeof(element_t);
+			}
+		};
+}
 #endif
 
 #if defined(_BOOST_UBLAS_VECTOR_) || defined(H5CPP_USE_UBLAS_VECTOR)
@@ -47,6 +64,9 @@ namespace h5::ublas {
 }
 namespace h5::meta {
 		template <class T> struct is_contiguous<h5::ublas::rowvec<T>> : std::true_type {};
+
+		// Register types so generic access_traits_t fallbacks don't create ambiguous partial specializations
+		template <class T> struct detail::has_explicit_access_traits<h5::ublas::rowvec<T>> : std::true_type {};
 }
 namespace h5::impl {
 	template <class T> struct detail::has_explicit_decay<h5::ublas::rowvec<T>> : std::true_type {};
@@ -67,5 +87,19 @@ namespace h5::impl {
 		static inline h5::ublas::rowvec<T> ctor( std::array<size_t,1> dims ){
 			return h5::ublas::rowvec<T>( dims[0] );
 	}};
+}
+namespace h5::meta {
+		template <class T> struct access_traits_t<h5::ublas::rowvec<T>> {
+			using element_t = T;
+			static constexpr access_t kind = access_t::contiguous;
+			static constexpr bool is_trivially_packable = true;
+			static auto data(const h5::ublas::rowvec<T>& c) noexcept { return h5::impl::data(c); }
+			static auto size(const h5::ublas::rowvec<T>& c) noexcept { return h5::impl::size(c); }
+			static std::size_t bytes(const h5::ublas::rowvec<T>& c) noexcept {
+				auto s = size(c); std::size_t n = 1;
+				for (std::size_t i = 0; i < s.size(); ++i) n *= s[i];
+				return n * sizeof(element_t);
+			}
+		};
 }
 #endif

--- a/h5cpp/H5Mxtensor.hpp
+++ b/h5cpp/H5Mxtensor.hpp
@@ -9,6 +9,8 @@
 
 namespace h5::impl {
 	// 1.) object -> H5T_xxx
+	template <class T> struct detail::has_explicit_decay<xt::xarray<T>> : std::true_type {};
+	template <class T, size_t N> struct detail::has_explicit_decay<xt::xtensor<T,N>> : std::true_type {};
 	template <class T> struct decay<xt::xarray<T>>{ using type = T; };
 	template <class T, size_t N> struct decay<xt::xtensor<T, N>>{ using type = T; };
 

--- a/h5cpp/H5Tmeta.hpp
+++ b/h5cpp/H5Tmeta.hpp
@@ -180,6 +180,42 @@ namespace h5::meta {
     };
 
     namespace detail_capabilities {
+
+    // Marker for types that have an explicit storage_representation_impl specialisation.
+    // The structural fallbacks (Gap 4) check this to avoid partial-specialisation
+    // ambiguity with the well-known STL container specs below.
+    // Third-party / user-defined containers should NOT specialise this — they rely
+    // on the structural fallback firing automatically.
+    template <class T> struct has_explicit_storage_repr : std::false_type {};
+    template <class T, class A>
+    struct has_explicit_storage_repr<std::vector<T,A>>           : std::true_type {};
+    template <class A>
+    struct has_explicit_storage_repr<std::vector<bool,A>>        : std::true_type {};
+    template <class T, std::size_t N>
+    struct has_explicit_storage_repr<std::array<T,N>>            : std::true_type {};
+    template <class T, class A>
+    struct has_explicit_storage_repr<std::deque<T,A>>            : std::true_type {};
+    template <class T, class A>
+    struct has_explicit_storage_repr<std::list<T,A>>             : std::true_type {};
+    template <class T, class A>
+    struct has_explicit_storage_repr<std::forward_list<T,A>>     : std::true_type {};
+    template <class T, class C, class A>
+    struct has_explicit_storage_repr<std::set<T,C,A>>            : std::true_type {};
+    template <class T, class C, class A>
+    struct has_explicit_storage_repr<std::multiset<T,C,A>>       : std::true_type {};
+    template <class T, class H, class E, class A>
+    struct has_explicit_storage_repr<std::unordered_set<T,H,E,A>>        : std::true_type {};
+    template <class T, class H, class E, class A>
+    struct has_explicit_storage_repr<std::unordered_multiset<T,H,E,A>>   : std::true_type {};
+    template <class K, class V, class C, class A>
+    struct has_explicit_storage_repr<std::map<K,V,C,A>>          : std::true_type {};
+    template <class K, class V, class C, class A>
+    struct has_explicit_storage_repr<std::multimap<K,V,C,A>>     : std::true_type {};
+    template <class K, class V, class H, class E, class A>
+    struct has_explicit_storage_repr<std::unordered_map<K,V,H,E,A>>      : std::true_type {};
+    template <class K, class V, class H, class E, class A>
+    struct has_explicit_storage_repr<std::unordered_multimap<K,V,H,E,A>> : std::true_type {};
+
     template <class T, class = void> struct storage_representation_impl
         : std::integral_constant<storage_representation_t, storage_representation_t::unsupported> {};
 
@@ -239,6 +275,24 @@ namespace h5::meta {
         : std::integral_constant<storage_representation_t, storage_representation_t::vlen_text_dataset> {};
     template <class T, std::size_t N, class A> struct storage_representation_impl<std::vector<std::array<T,N>,A>>
         : std::integral_constant<storage_representation_t, storage_representation_t::fixed_inner_extent_dataset> {};
+
+    // Gap 4: structural fallbacks for third-party / unregistered containers.
+    // has_explicit_storage_repr<T> guards against ambiguity with the STL explicit
+    // specs above; any type NOT in that set reaches these fallbacks automatically.
+    // Sequential-like (has begin/end/value_type, no key_type/mapped_type, not text/bitfield):
+    template <class T>
+    struct storage_representation_impl<T, std::enable_if_t<
+        is_sequential_like<T>::value &&
+        !is_text_like<T>::value &&
+        !is_bitfield_like<T>::value &&
+        !has_explicit_storage_repr<T>::value>>
+        : std::integral_constant<storage_representation_t, storage_representation_t::linear_value_dataset> {};
+    // Map-like (has key_type + mapped_type):
+    template <class T>
+    struct storage_representation_impl<T, std::enable_if_t<
+        is_map_like<T>::value &&
+        !has_explicit_storage_repr<T>::value>>
+        : std::integral_constant<storage_representation_t, storage_representation_t::key_value_dataset> {};
     }
 
     template <class T> struct storage_representation
@@ -415,6 +469,20 @@ namespace h5::meta {
         static constexpr bool value = check_contiguous(std::make_index_sequence<std::tuple_size_v<fields_t>>{});
     };
 
+    // Gap 1: contiguous STL sequence containers (vector<T>, span<T>, etc.)
+    // Triggers when T exposes a data() pointer and size(), but is not a C/std::array,
+    // not text, not arithmetic, and not a reflected compound.
+    // Contiguity recurses into the element type via meta::decay (which uses value_type).
+    template <class T>
+    struct is_transport_contiguous_impl_t<T, std::enable_if_t<
+        !is_array_like<T>::value &&
+        !is_text_like<T>::value &&
+        !is_reflected_compound_t<T>::value &&
+        !std::is_arithmetic_v<T> &&
+        has_data_pointer<T>::value &&
+        meta::has_size<T>::value>>
+        : is_transport_contiguous_t<typename meta::decay<T>::type> {};
+
     // DEFAULT CASE
     template <class T> struct rank<T*>: public std::integral_constant<size_t,1>{};
     template <class T, class... Ts>
@@ -528,4 +596,112 @@ namespace h5::meta {
     template <> struct is_location<h5::fd_t> : std::true_type {};
 
     //template <class T> struct 
+}
+
+// Gap 3: access_t enum and access_traits_t<T> — the executable memory-access contract.
+// Describes how to obtain a data pointer, size, and byte count for a given type.
+// Used to decouple I/O dispatch from concrete container types.
+namespace h5::meta {
+    enum class access_t {
+        object,      // scalar / arithmetic / reflected compound — single addressable value
+        contiguous,  // has .data() pointer + is_transport_contiguous (bulk memcpy safe)
+        pointers,    // has .data() but element is not flat (e.g., vector<string>)
+        iterators,   // begin/end traversal only — no direct pointer
+        unsupported
+    };
+
+    // Primary (unsupported — no match)
+    template <class T, class = void>
+    struct access_traits_t {
+        static constexpr access_t kind = access_t::unsupported;
+    };
+
+    // Arithmetic scalars and enums
+    template <class T>
+    struct access_traits_t<T, std::enable_if_t<std::is_arithmetic_v<T> || std::is_enum_v<T>>> {
+        using element_t  = T;
+        using pointer_t  = const T*;
+        static constexpr access_t kind = access_t::object;
+        static constexpr bool is_trivially_packable = true;
+        static const T*  data(const T& v)  noexcept { return &v; }
+        static T*        data(T& v)        noexcept { return &v; }
+        static constexpr std::array<std::size_t,0> size(const T&) noexcept { return {}; }
+        static constexpr std::size_t bytes(const T&) noexcept { return sizeof(T); }
+    };
+
+    // Reflected compound structs
+    template <class T>
+    struct access_traits_t<T, std::enable_if_t<is_reflected_compound_t<T>::value>> {
+        using element_t  = T;
+        using pointer_t  = const T*;
+        static constexpr access_t kind = access_t::object;
+        static constexpr bool is_trivially_packable = is_transport_contiguous_v<T>;
+        static const T*  data(const T& v)  noexcept { return &v; }
+        static T*        data(T& v)        noexcept { return &v; }
+        static constexpr std::array<std::size_t,0> size(const T&) noexcept { return {}; }
+        static constexpr std::size_t bytes(const T&) noexcept { return sizeof(T); }
+    };
+
+    // C-style arrays T[N] — contiguous by definition
+    template <class T, std::size_t N>
+    struct access_traits_t<T[N]> {
+        using element_t  = typename std::remove_all_extents_t<T[N]>;
+        using pointer_t  = const element_t*;
+        static constexpr access_t kind = access_t::contiguous;
+        static constexpr bool is_trivially_packable = true;
+        static const element_t* data(const T(&a)[N]) noexcept { return reinterpret_cast<const element_t*>(a); }
+        static element_t*       data(T(&a)[N])       noexcept { return reinterpret_cast<element_t*>(a); }
+        static constexpr std::array<std::size_t,1> size(const T(&)[N]) noexcept { return {N}; }
+        static constexpr std::size_t bytes(const T(&)[N]) noexcept { return N * sizeof(T); }
+    };
+
+    // Contiguous sequence containers: has .data() pointer + transport contiguous element
+    template <class T>
+    struct access_traits_t<T, std::enable_if_t<
+        !std::is_array_v<T> &&
+        !is_reflected_compound_t<T>::value &&
+        has_data_pointer<T>::value &&
+        meta::has_size<T>::value &&
+        is_transport_contiguous_v<T>>> {
+        using element_t  = std::remove_pointer_t<
+                               compat::detected_or_t<void*, data_f, remove_cvref_t<T>>>;
+        using pointer_t  = const element_t*;
+        static constexpr access_t kind = access_t::contiguous;
+        static constexpr bool is_trivially_packable = true;
+        static auto data(const T& c) noexcept { return c.data(); }
+        static auto data(T& c)       noexcept { return c.data(); }
+        static std::array<std::size_t,1> size(const T& c) noexcept { return {c.size()}; }
+        static std::size_t bytes(const T& c) noexcept { return c.size() * sizeof(element_t); }
+    };
+
+    // Non-contiguous sequence containers with .data() (e.g., vector<string>)
+    template <class T>
+    struct access_traits_t<T, std::enable_if_t<
+        !std::is_array_v<T> &&
+        !is_reflected_compound_t<T>::value &&
+        has_data_pointer<T>::value &&
+        meta::has_size<T>::value &&
+        !is_transport_contiguous_v<T>>> {
+        using element_t  = typename remove_cvref_t<T>::value_type;
+        static constexpr access_t kind = access_t::pointers;
+        static constexpr bool is_trivially_packable = false;
+        static auto data(const T& c) noexcept { return c.data(); }
+        static std::array<std::size_t,1> size(const T& c) noexcept { return {c.size()}; }
+    };
+
+    // Iterator-only containers: begin/end but no .data() (list, set, map, ...)
+    template <class T>
+    struct access_traits_t<T, std::enable_if_t<
+        !std::is_array_v<T> &&
+        !has_data_pointer<T>::value &&
+        meta::has_iterator<T>::value &&
+        compat::is_detected<value_type_f, remove_cvref_t<T>>::value>> {
+        using element_t  = typename remove_cvref_t<T>::value_type;
+        static constexpr access_t kind = access_t::iterators;
+        static constexpr bool is_trivially_packable = false;
+        static std::array<std::size_t,1> size(const T& c) noexcept { return {std::distance(c.begin(), c.end())}; }
+    };
+
+    template <class T>
+    inline constexpr access_t access_kind_v = access_traits_t<remove_cvref_t<T>>::kind;
 }

--- a/h5cpp/H5Tmeta.hpp
+++ b/h5cpp/H5Tmeta.hpp
@@ -479,6 +479,7 @@ namespace h5::meta {
         !is_text_like<T>::value &&
         !is_reflected_compound_t<T>::value &&
         !std::is_arithmetic_v<T> &&
+        meta::has_value_type<T>::value &&
         has_data_pointer<T>::value &&
         meta::has_size<T>::value>>
         : is_transport_contiguous_t<typename meta::decay<T>::type> {};
@@ -607,6 +608,7 @@ namespace h5::meta {
         contiguous,  // has .data() pointer + is_transport_contiguous (bulk memcpy safe)
         pointers,    // has .data() but element is not flat (e.g., vector<string>)
         iterators,   // begin/end traversal only — no direct pointer
+        text,        // variable-length or fixed-length text (std::string, char*, etc.)
         unsupported
     };
 
@@ -640,6 +642,21 @@ namespace h5::meta {
         static T*        data(T& v)        noexcept { return &v; }
         static constexpr std::array<std::size_t,0> size(const T&) noexcept { return {}; }
         static constexpr std::size_t bytes(const T&) noexcept { return sizeof(T); }
+    };
+
+    // Text-like types (std::string, std::string_view, etc.) — handled by HDF5 string types, not raw memcpy
+    template <class T>
+    struct access_traits_t<T, std::enable_if_t<
+        is_text_like<T>::value &&
+        !std::is_array_v<T> &&
+        !std::is_pointer_v<remove_cvref_t<T>>>> {
+        using element_t  = typename remove_cvref_t<T>::value_type;
+        using pointer_t  = const element_t*;
+        static constexpr access_t kind = access_t::text;
+        static constexpr bool is_trivially_packable = false;
+        static auto data(const T& s) noexcept { return s.data(); }
+        static auto data(T& s)       noexcept { return s.data(); }
+        static std::array<std::size_t,1> size(const T& s) noexcept { return {s.size()}; }
     };
 
     // C-style arrays T[N] — contiguous by definition
@@ -681,6 +698,7 @@ namespace h5::meta {
         !is_reflected_compound_t<T>::value &&
         has_data_pointer<T>::value &&
         meta::has_size<T>::value &&
+        compat::is_detected<value_type_f, remove_cvref_t<T>>::value &&
         !is_transport_contiguous_v<T>>> {
         using element_t  = typename remove_cvref_t<T>::value_type;
         static constexpr access_t kind = access_t::pointers;
@@ -699,7 +717,12 @@ namespace h5::meta {
         using element_t  = typename remove_cvref_t<T>::value_type;
         static constexpr access_t kind = access_t::iterators;
         static constexpr bool is_trivially_packable = false;
-        static std::array<std::size_t,1> size(const T& c) noexcept { return {std::distance(c.begin(), c.end())}; }
+        static std::array<std::size_t,1> size(const T& c) noexcept {
+            if constexpr (meta::has_size<T>::value)
+                return {c.size()};
+            else
+                return {std::distance(c.begin(), c.end())};
+        }
     };
 
     template <class T>

--- a/h5cpp/H5Tmeta.hpp
+++ b/h5cpp/H5Tmeta.hpp
@@ -469,20 +469,28 @@ namespace h5::meta {
         static constexpr bool value = check_contiguous(std::make_index_sequence<std::tuple_size_v<fields_t>>{});
     };
 
-    // Gap 1: contiguous STL sequence containers (vector<T>, span<T>, etc.)
+    // Gap 1: contiguous STL sequence containers (vector<T>, span<T>, linalg types, etc.)
     // Triggers when T exposes a data() pointer and size(), but is not a C/std::array,
     // not text, not arithmetic, and not a reflected compound.
-    // Contiguity recurses into the element type via meta::decay (which uses value_type).
+    // The element type inferred from data() must be standard-layout and trivial
+    // (prevents nested containers like vector<vector<T>> or vector<string> from matching).
     template <class T>
     struct is_transport_contiguous_impl_t<T, std::enable_if_t<
         !is_array_like<T>::value &&
         !is_text_like<T>::value &&
         !is_reflected_compound_t<T>::value &&
         !std::is_arithmetic_v<T> &&
-        meta::has_value_type<T>::value &&
         has_data_pointer<T>::value &&
-        meta::has_size<T>::value>>
-        : is_transport_contiguous_t<typename meta::decay<T>::type> {};
+        meta::has_size<T>::value &&
+        std::is_standard_layout_v<
+            std::remove_pointer_t<
+                compat::detected_or_t<void, data_f, remove_cvref_t<T>>>> &&
+        std::is_trivial_v<
+            std::remove_pointer_t<
+                compat::detected_or_t<void, data_f, remove_cvref_t<T>>>>>>
+        : is_transport_contiguous_t<
+            std::remove_pointer_t<
+                compat::detected_or_t<void, data_f, remove_cvref_t<T>>>> {};
 
     // DEFAULT CASE
     template <class T> struct rank<T*>: public std::integral_constant<size_t,1>{};
@@ -612,6 +620,13 @@ namespace h5::meta {
         unsupported
     };
 
+    // Registry for types with explicit access_traits_t specializations in mapper files.
+    // Prevents ambiguous partial-specialization resolution between generic fallbacks
+    // and mapper-provided access_traits_t.
+    namespace detail {
+        template <class T> struct has_explicit_access_traits : std::false_type {};
+    }
+
     // Primary (unsupported — no match)
     template <class T, class = void>
     struct access_traits_t {
@@ -647,6 +662,7 @@ namespace h5::meta {
     // Text-like types (std::string, std::string_view, etc.) — handled by HDF5 string types, not raw memcpy
     template <class T>
     struct access_traits_t<T, std::enable_if_t<
+        !detail::has_explicit_access_traits<remove_cvref_t<T>>::value &&
         is_text_like<T>::value &&
         !std::is_array_v<T> &&
         !std::is_pointer_v<remove_cvref_t<T>>>> {
@@ -675,6 +691,7 @@ namespace h5::meta {
     // Contiguous sequence containers: has .data() pointer + transport contiguous element
     template <class T>
     struct access_traits_t<T, std::enable_if_t<
+        !detail::has_explicit_access_traits<remove_cvref_t<T>>::value &&
         !std::is_array_v<T> &&
         !is_reflected_compound_t<T>::value &&
         has_data_pointer<T>::value &&
@@ -694,6 +711,7 @@ namespace h5::meta {
     // Non-contiguous sequence containers with .data() (e.g., vector<string>)
     template <class T>
     struct access_traits_t<T, std::enable_if_t<
+        !detail::has_explicit_access_traits<remove_cvref_t<T>>::value &&
         !std::is_array_v<T> &&
         !is_reflected_compound_t<T>::value &&
         has_data_pointer<T>::value &&
@@ -710,6 +728,7 @@ namespace h5::meta {
     // Iterator-only containers: begin/end but no .data() (list, set, map, ...)
     template <class T>
     struct access_traits_t<T, std::enable_if_t<
+        !detail::has_explicit_access_traits<remove_cvref_t<T>>::value &&
         !std::is_array_v<T> &&
         !has_data_pointer<T>::value &&
         meta::has_iterator<T>::value &&


### PR DESCRIPTION
Closes #89

Refactors H5Dwrite dispatch to use access_traits_t-driven classification (contiguous/object/text/pointers/iterators/unsupported) with explicit linalg mapper support.

- Adds access_traits_t, is_transport_contiguous_t, storage_representation_t, resolved_type_t to H5Tmeta
- Registers has_explicit_access_traits for Blaze, Armadillo, dlib, itpp, ublas, blitz, xtensor
- Gap 1 fix: derives element type from data() return type for structural fallbacks
- 44/44 tests passing