### PR TITLE
[#195]:svarga:feature, add H5Qall.hpp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -484,7 +484,7 @@ jobs:
 
           cmake -S . -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Debug \
-            -DCMAKE_CXX_STANDARD=17 \
+            -DCMAKE_CXX_STANDARD=20 \
             -DCMAKE_C_COMPILER=gcc-14 \
             -DCMAKE_CXX_COMPILER=g++-14 \
             -DCMAKE_C_FLAGS="--coverage -O0 -g" \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ cmake_minimum_required(VERSION 3.22.0)
 project(libh5cpp-dev VERSION 1.10.4.6 LANGUAGES CXX C)
 
 # ─── Standard Settings ────────────────────────────────────────────────────────────
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
@@ -192,7 +192,7 @@ target_include_directories(h5cpp INTERFACE
 )
 
 target_link_libraries(h5cpp INTERFACE ${H5CPP_LIBS})
-target_compile_features(h5cpp INTERFACE cxx_std_17)
+target_compile_features(h5cpp INTERFACE cxx_std_20)
 
 if(H5CPP_HAVE_ROS3_VFD)
     target_compile_definitions(h5cpp INTERFACE H5CPP_HAVE_ROS3_VFD=1)

--- a/h5cpp/H5Qall.hpp
+++ b/h5cpp/H5Qall.hpp
@@ -1,0 +1,741 @@
+/*
+ * SPDX-License-Identifier: MIT
+ *
+ * Copyright (c) 2025-2026 Varga Labs, Toronto, ON, Canada
+ * Author: Varga, Steven <steven@vargaconsulting.ca>
+ *
+ * Bounded lock-free queue and ring-buffer arena — amalgamated for h5cpp.
+ * Ported from sigma/include/sigma/{queue,ring}.hpp under MIT relicense.
+ *
+ * Requires C++20: std::bit_ceil, std::atomic::wait/notify, std::stop_token.
+ *
+ * Namespaces provided:
+ *   bounded::spsc::queue_t<T,N>  — 1 producer, 1 consumer
+ *   bounded::mpsc::queue_t<T,N>  — M producers, 1 consumer  (Vyukov)
+ *   bounded::spmc::queue_t<T,N>  — 1 producer, M consumers  (Vyukov)
+ *   bounded::mpmc::queue_t<T,N>  — M producers, M consumers (Vyukov)
+ *   bounded::ring::adaptor_t     — byte-arena ring on top of any queue_t
+ *   bounded::ring::spsc_t<N,K>   — spsc ring alias (N ctrl slots, K bytes)
+ *   bounded::ring::mpsc_t<N,K>   — mpsc ring alias
+ *   sigma::doorbell_t            — standalone notify primitive
+ *
+ * h5::impl aliases (h5-scoped names for the I/O layer):
+ *   h5::impl::spsc_queue_t<T,N>
+ *   h5::impl::mpsc_queue_t<T,N>
+ *   h5::impl::spmc_queue_t<T,N>
+ *   h5::impl::mpmc_queue_t<T,N>
+ *   h5::impl::ring_spsc_t<N,K>
+ *   h5::impl::ring_mpsc_t<N,K>
+ *   h5::impl::staging_ring_t<NP,NC,N,K>  — selects spsc or mpsc by concurrency
+ */
+#pragma once
+
+#if __cplusplus < 202002L
+#  error "H5Qall.hpp requires C++20 or later"
+#endif
+
+#include <array>
+#include <atomic>
+#include <bit>          // std::bit_ceil — C++20
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <new>
+#include <optional>
+#include <stop_token>   // std::stop_token — C++20
+#include <type_traits>
+#include <utility>
+
+// ============================================================================
+// bounded::impl — internal slot / cell / alignment helpers
+// ============================================================================
+namespace bounded::impl {
+
+    // hardware_destructive_interference_size in libstdc++ is gated on
+    // __GCC_DESTRUCTIVE_SIZE, which GCC always defines but Clang only sets from
+    // version 19 onward.  Apple Clang (libc++) derives the constant independently
+    // and is unaffected.  Fall back to 64 — correct for x86-64 and Apple Silicon.
+    //
+    // GCC emits -Winterference-size when the constant is used in a header because
+    // the value is technically target-tuning-dependent.  The queue internals are
+    // never part of a cross-TU ABI boundary, so the warning is not actionable here.
+#ifdef __cpp_lib_hardware_interference_size
+#  if defined(__GNUC__) && !defined(__clang__)
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Winterference-size"
+#  endif
+    inline constexpr std::size_t cache_line_size_v =
+        std::hardware_destructive_interference_size;
+#  if defined(__GNUC__) && !defined(__clang__)
+#    pragma GCC diagnostic pop
+#  endif
+#else
+    inline constexpr std::size_t cache_line_size_v = 64;
+#endif
+
+    constexpr std::size_t ceil_pow2(std::size_t x) noexcept {
+        if (x <= 1) return 1;
+        return std::bit_ceil(x);
+    }
+
+    template<typename T>
+    struct slot_t {
+        T* ptr() noexcept {
+            return std::launder(reinterpret_cast<T*>(&storage[0]));
+        }
+        const T* ptr() const noexcept {
+            return std::launder(reinterpret_cast<const T*>(&storage[0]));
+        }
+        template<typename... args_t>
+        void emplace(args_t&&... args)
+            noexcept(std::is_nothrow_constructible_v<T, args_t...>)
+        {
+            ::new (static_cast<void*>(&storage[0])) T(std::forward<args_t>(args)...);
+        }
+        void destroy() noexcept(std::is_nothrow_destructible_v<T>) {
+            std::destroy_at(ptr());
+        }
+        alignas(T) std::byte storage[sizeof(T)];
+    };
+
+    constexpr std::size_t align_up(std::size_t n, std::size_t a) noexcept {
+        return (n + (a - 1)) & ~(a - 1);
+    }
+
+    template<typename T>
+    struct alignas(cache_line_size_v) cell_t {
+        std::atomic<std::size_t> seq{0};
+        slot_t<T> slot;
+        static constexpr std::size_t payload_size_v =
+            sizeof(std::atomic<std::size_t>) + sizeof(slot_t<T>);
+        static constexpr std::size_t padded_size_v =
+            align_up(payload_size_v, cache_line_size_v);
+        static constexpr std::size_t pad_size_v =
+            padded_size_v - payload_size_v;
+        [[no_unique_address]] std::byte pad[pad_size_v ? pad_size_v : 1];
+    };
+
+    static_assert(alignof(cell_t<int>) >= cache_line_size_v);
+
+} // namespace bounded::impl
+
+// ============================================================================
+// sigma::doorbell_t — standalone atomic notify primitive
+// ============================================================================
+namespace sigma {
+
+    struct alignas(bounded::impl::cache_line_size_v) doorbell_t {
+        void ring() noexcept {
+            seq.fetch_add(1, std::memory_order_release);
+            seq.notify_one();
+        }
+        void ring_all() noexcept {
+            seq.fetch_add(1, std::memory_order_release);
+            seq.notify_all();
+        }
+        std::atomic<std::uint32_t> seq{0};
+    };
+
+} // namespace sigma
+
+// ============================================================================
+// bounded::spsc — single-producer, single-consumer queue
+// ============================================================================
+namespace bounded::spsc {
+
+    template<typename T, std::size_t capacity>
+    struct queue_t {
+        using cache_line_t =
+            std::integral_constant<std::size_t,
+                bounded::impl::cache_line_size_v>;
+
+        queue_t() = default;
+        queue_t(const queue_t&) = delete;
+        queue_t& operator=(const queue_t&) = delete;
+
+        ~queue_t() {
+            auto t = tail.load(std::memory_order_relaxed);
+            const auto h = head.load(std::memory_order_relaxed);
+            while (t != h) {
+                buffer[t].destroy();
+                t = (t + 1) & mask;
+            }
+        }
+
+        static constexpr std::size_t raw_capacity()    noexcept { return capacity_pow2; }
+        static constexpr std::size_t usable_capacity() noexcept { return capacity_pow2 - 1; }
+
+        bool empty() const noexcept {
+            const auto t = tail.load(std::memory_order_relaxed);
+            const auto h = head.load(std::memory_order_acquire);
+            return t == h;
+        }
+        bool full() const noexcept {
+            const auto h    = head.load(std::memory_order_relaxed);
+            const auto next = (h + 1) & mask;
+            const auto t    = tail.load(std::memory_order_acquire);
+            return next == t;
+        }
+        std::size_t approx_size() const noexcept {
+            const auto t = tail.load(std::memory_order_acquire);
+            const auto h = head.load(std::memory_order_acquire);
+            return (h - t) & mask;
+        }
+
+        bool push(const T& v) noexcept(std::is_nothrow_copy_constructible_v<T>) {
+            return emplace(v);
+        }
+        bool push(T&& v) noexcept(std::is_nothrow_move_constructible_v<T>) {
+            return emplace(std::move(v));
+        }
+        template<typename... args_t>
+        bool emplace(args_t&&... args)
+            noexcept(std::is_nothrow_constructible_v<T, args_t...>)
+        {
+            const auto h    = head.load(std::memory_order_relaxed);
+            const auto next = (h + 1) & mask;
+            if (next == tail.load(std::memory_order_acquire)) return false;
+            buffer[h].emplace(std::forward<args_t>(args)...);
+            head.store(next, std::memory_order_release);
+            seq.fetch_add(1, std::memory_order_release);
+            seq.notify_one();
+            return true;
+        }
+        bool pop(T& out)
+            noexcept(std::is_nothrow_move_assignable_v<T> &&
+                     std::is_nothrow_move_constructible_v<T>)
+        {
+            const auto t = tail.load(std::memory_order_relaxed);
+            if (t == head.load(std::memory_order_acquire)) return false;
+            out = std::move(*buffer[t].ptr());
+            buffer[t].destroy();
+            tail.store((t + 1) & mask, std::memory_order_release);
+            return true;
+        }
+        bool wait_pop(T& out, std::stop_token st)
+            noexcept(std::is_nothrow_move_assignable_v<T> &&
+                     std::is_nothrow_move_constructible_v<T>)
+        {
+            std::stop_callback on_stop(st, [this]() noexcept { notify_all(); });
+            auto last_seq = sequence();
+            while (!st.stop_requested()) {
+                if (pop(out)) return true;
+                if (!wait_for_data(st, last_seq)) return false;
+            }
+            return false;
+        }
+        std::uint32_t sequence() const noexcept {
+            return seq.load(std::memory_order_acquire);
+        }
+        void notify_all() noexcept {
+            seq.fetch_add(1, std::memory_order_release);
+            seq.notify_all();
+        }
+        bool wait_for_data(std::stop_token st, std::uint32_t& last_seq) const noexcept {
+            if (st.stop_requested()) return false;
+            if (!empty()) return true;
+            seq.wait(last_seq, std::memory_order_acquire);
+            last_seq = seq.load(std::memory_order_acquire);
+            return !st.stop_requested();
+        }
+
+        static constexpr std::size_t capacity_pow2 = impl::ceil_pow2(capacity);
+        static_assert(capacity_pow2 >= 2, "capacity must be >= 2");
+        static constexpr std::size_t mask = capacity_pow2 - 1;
+
+        alignas(cache_line_t::value) std::atomic<std::size_t>  head{0};
+        alignas(cache_line_t::value) std::atomic<std::size_t>  tail{0};
+        alignas(cache_line_t::value) std::atomic<std::uint32_t> seq{0};
+        std::array<impl::slot_t<T>, capacity_pow2> buffer;
+    };
+
+} // namespace bounded::spsc
+
+// ============================================================================
+// bounded::mpsc — many-producer, single-consumer (Vyukov)
+// ============================================================================
+namespace bounded::mpsc {
+
+    template<typename T, std::size_t capacity>
+    struct queue_t {
+        using cache_line_t =
+            std::integral_constant<std::size_t,
+                bounded::impl::cache_line_size_v>;
+
+        queue_t() noexcept {
+            for (std::size_t i = 0; i < capacity_pow2; ++i)
+                buffer[i].seq.store(i, std::memory_order_relaxed);
+        }
+        queue_t(const queue_t&) = delete;
+        queue_t& operator=(const queue_t&) = delete;
+        ~queue_t() {
+            T tmp;
+            while (pop(tmp)) {}
+        }
+
+        static constexpr std::size_t raw_capacity()    noexcept { return capacity_pow2; }
+        static constexpr std::size_t usable_capacity() noexcept { return capacity_pow2; }
+
+        bool empty_approx() const noexcept {
+            return tail.load(std::memory_order_acquire) ==
+                   head.load(std::memory_order_acquire);
+        }
+        std::size_t approx_size() const noexcept {
+            const auto t = tail.load(std::memory_order_acquire);
+            const auto h = head.load(std::memory_order_acquire);
+            return (h >= t) ? (h - t) : 0;
+        }
+
+        bool push(const T& v) noexcept(std::is_nothrow_copy_constructible_v<T>) {
+            return emplace(v);
+        }
+        bool push(T&& v) noexcept(std::is_nothrow_move_constructible_v<T>) {
+            return emplace(std::move(v));
+        }
+        template<typename... args_t>
+        bool emplace(args_t&&... args)
+            noexcept(std::is_nothrow_constructible_v<T, args_t...>)
+        {
+            std::size_t pos = head.load(std::memory_order_relaxed);
+            while (true) {
+                auto& cell      = buffer[pos & mask];
+                const auto cseq = cell.seq.load(std::memory_order_acquire);
+                const auto dif  = static_cast<std::ptrdiff_t>(cseq) -
+                                  static_cast<std::ptrdiff_t>(pos);
+                if (dif == 0) {
+                    if (head.compare_exchange_weak(pos, pos + 1,
+                            std::memory_order_relaxed, std::memory_order_relaxed)) {
+                        cell.slot.emplace(std::forward<args_t>(args)...);
+                        cell.seq.store(pos + 1, std::memory_order_release);
+                        doorbell.fetch_add(1, std::memory_order_release);
+                        doorbell.notify_one();
+                        return true;
+                    }
+                } else if (dif < 0) {
+                    return false; // full
+                } else {
+                    pos = head.load(std::memory_order_relaxed);
+                }
+            }
+        }
+        bool pop(T& out)
+            noexcept(std::is_nothrow_move_assignable_v<T> &&
+                     std::is_nothrow_move_constructible_v<T>)
+        {
+            const auto pos  = tail.load(std::memory_order_relaxed);
+            auto& cell      = buffer[pos & mask];
+            const auto cseq = cell.seq.load(std::memory_order_acquire);
+            const auto dif  = static_cast<std::ptrdiff_t>(cseq) -
+                              static_cast<std::ptrdiff_t>(pos + 1);
+            if (dif < 0) return false;
+            out = std::move(*cell.slot.ptr());
+            cell.slot.destroy();
+            cell.seq.store(pos + capacity_pow2, std::memory_order_release);
+            tail.store(pos + 1, std::memory_order_release);
+            return true;
+        }
+        bool wait_pop(T& out, std::stop_token st)
+            noexcept(std::is_nothrow_move_assignable_v<T> &&
+                     std::is_nothrow_move_constructible_v<T>)
+        {
+            std::stop_callback on_stop(st, [this]() noexcept { notify_all(); });
+            auto last = sequence();
+            while (!st.stop_requested()) {
+                if (pop(out)) return true;
+                if (!wait_for_data(st, last)) return false;
+            }
+            return false;
+        }
+        std::uint32_t sequence() const noexcept {
+            return doorbell.load(std::memory_order_acquire);
+        }
+        void notify_all() noexcept {
+            doorbell.fetch_add(1, std::memory_order_release);
+            doorbell.notify_all();
+        }
+        bool wait_for_data(std::stop_token st, std::uint32_t& last) const noexcept {
+            if (st.stop_requested()) return false;
+            if (doorbell.load(std::memory_order_acquire) != last) return true;
+            doorbell.wait(last, std::memory_order_acquire);
+            last = doorbell.load(std::memory_order_acquire);
+            return !st.stop_requested();
+        }
+
+        static constexpr std::size_t capacity_pow2 = impl::ceil_pow2(capacity);
+        static_assert(capacity_pow2 >= 2, "capacity must be >= 2");
+        static constexpr std::size_t mask = capacity_pow2 - 1;
+
+        alignas(cache_line_t::value) std::atomic<std::size_t>  head{0};
+        alignas(cache_line_t::value) std::atomic<std::size_t>  tail{0};
+        alignas(cache_line_t::value) std::atomic<std::uint32_t> doorbell{0};
+        std::array<impl::cell_t<T>, capacity_pow2> buffer;
+    };
+
+} // namespace bounded::mpsc
+
+// ============================================================================
+// bounded::spmc — single-producer, many-consumer (Vyukov)
+// ============================================================================
+namespace bounded::spmc {
+
+    template<typename T, std::size_t capacity>
+    struct queue_t {
+        using cache_line_t =
+            std::integral_constant<std::size_t,
+                bounded::impl::cache_line_size_v>;
+
+        queue_t() noexcept {
+            for (std::size_t i = 0; i < capacity_pow2; ++i)
+                buffer[i].seq.store(i, std::memory_order_relaxed);
+        }
+        queue_t(const queue_t&) = delete;
+        queue_t& operator=(const queue_t&) = delete;
+        ~queue_t() {
+            T tmp;
+            while (pop(tmp)) {}
+        }
+
+        static constexpr std::size_t raw_capacity()    noexcept { return capacity_pow2; }
+        static constexpr std::size_t usable_capacity() noexcept { return capacity_pow2; }
+
+        bool push(const T& v) noexcept(std::is_nothrow_copy_constructible_v<T>) {
+            return emplace(v);
+        }
+        bool push(T&& v) noexcept(std::is_nothrow_move_constructible_v<T>) {
+            return emplace(std::move(v));
+        }
+        template<typename... args_t>
+        bool emplace(args_t&&... args)
+            noexcept(std::is_nothrow_constructible_v<T, args_t...>)
+        {
+            const auto pos  = head.load(std::memory_order_relaxed);
+            auto& cell      = buffer[pos & mask];
+            const auto cseq = cell.seq.load(std::memory_order_acquire);
+            const auto dif  = static_cast<std::ptrdiff_t>(cseq) -
+                              static_cast<std::ptrdiff_t>(pos);
+            if (dif < 0) return false;
+            cell.slot.emplace(std::forward<args_t>(args)...);
+            cell.seq.store(pos + 1, std::memory_order_release);
+            head.store(pos + 1, std::memory_order_release);
+            doorbell.fetch_add(1, std::memory_order_release);
+            doorbell.notify_one();
+            return true;
+        }
+        bool pop(T& out)
+            noexcept(std::is_nothrow_move_assignable_v<T> &&
+                     std::is_nothrow_move_constructible_v<T>)
+        {
+            std::size_t pos = tail.load(std::memory_order_relaxed);
+            while (true) {
+                auto& cell      = buffer[pos & mask];
+                const auto cseq = cell.seq.load(std::memory_order_acquire);
+                const auto dif  = static_cast<std::ptrdiff_t>(cseq) -
+                                  static_cast<std::ptrdiff_t>(pos + 1);
+                if (dif < 0) return false;
+                if (dif == 0) {
+                    if (tail.compare_exchange_weak(pos, pos + 1,
+                            std::memory_order_relaxed, std::memory_order_relaxed)) {
+                        out = std::move(*cell.slot.ptr());
+                        cell.slot.destroy();
+                        cell.seq.store(pos + capacity_pow2, std::memory_order_release);
+                        return true;
+                    }
+                } else {
+                    pos = tail.load(std::memory_order_relaxed);
+                }
+            }
+        }
+        bool wait_pop(T& out, std::stop_token st)
+            noexcept(std::is_nothrow_move_assignable_v<T> &&
+                     std::is_nothrow_move_constructible_v<T>)
+        {
+            std::stop_callback on_stop(st, [this]() noexcept { notify_all(); });
+            auto last_seq = sequence();
+            while (!st.stop_requested()) {
+                if (pop(out)) return true;
+                if (!wait_for_data(st, last_seq)) return false;
+            }
+            return false;
+        }
+        std::uint32_t sequence() const noexcept {
+            return doorbell.load(std::memory_order_acquire);
+        }
+        void notify_all() noexcept {
+            doorbell.fetch_add(1, std::memory_order_release);
+            doorbell.notify_all();
+        }
+        bool wait_for_data(std::stop_token st, std::uint32_t& last_seq) const noexcept {
+            if (st.stop_requested()) return false;
+            if (doorbell.load(std::memory_order_acquire) != last_seq) return true;
+            doorbell.wait(last_seq, std::memory_order_acquire);
+            last_seq = doorbell.load(std::memory_order_acquire);
+            return !st.stop_requested();
+        }
+
+        static constexpr std::size_t capacity_pow2 = impl::ceil_pow2(capacity);
+        static_assert(capacity_pow2 >= 2, "capacity must be >= 2");
+        static constexpr std::size_t mask = capacity_pow2 - 1;
+
+        alignas(cache_line_t::value) std::atomic<std::size_t>  head{0};
+        alignas(cache_line_t::value) std::atomic<std::size_t>  tail{0};
+        alignas(cache_line_t::value) std::atomic<std::uint32_t> doorbell{0};
+        std::array<impl::cell_t<T>, capacity_pow2> buffer;
+    };
+
+} // namespace bounded::spmc
+
+// ============================================================================
+// bounded::mpmc — many-producer, many-consumer (Vyukov)
+// ============================================================================
+namespace bounded::mpmc {
+
+    template<typename T, std::size_t capacity>
+    struct queue_t {
+        using cache_line_t =
+            std::integral_constant<std::size_t,
+                bounded::impl::cache_line_size_v>;
+
+        queue_t() noexcept {
+            for (std::size_t i = 0; i < capacity_pow2; ++i)
+                buffer[i].seq.store(i, std::memory_order_relaxed);
+        }
+        queue_t(const queue_t&) = delete;
+        queue_t& operator=(const queue_t&) = delete;
+        ~queue_t() {
+            T tmp;
+            while (try_pop(tmp)) {}
+        }
+
+        static constexpr std::size_t raw_capacity()    noexcept { return capacity_pow2; }
+        static constexpr std::size_t usable_capacity() noexcept { return capacity_pow2; }
+
+        bool try_push(const T& v) noexcept(std::is_nothrow_copy_constructible_v<T>) {
+            return try_emplace(v);
+        }
+        bool try_push(T&& v) noexcept(std::is_nothrow_move_constructible_v<T>) {
+            return try_emplace(std::move(v));
+        }
+        template<typename... args_t>
+        bool try_emplace(args_t&&... args)
+            noexcept(std::is_nothrow_constructible_v<T, args_t...>)
+        {
+            std::size_t pos = head.load(std::memory_order_relaxed);
+            while (true) {
+                auto& cell      = buffer[pos & mask];
+                const auto cseq = cell.seq.load(std::memory_order_acquire);
+                const auto dif  = static_cast<std::ptrdiff_t>(cseq) -
+                                  static_cast<std::ptrdiff_t>(pos);
+                if (dif == 0) {
+                    if (head.compare_exchange_weak(pos, pos + 1,
+                            std::memory_order_relaxed, std::memory_order_relaxed)) {
+                        cell.slot.emplace(std::forward<args_t>(args)...);
+                        cell.seq.store(pos + 1, std::memory_order_release);
+                        doorbell.fetch_add(1, std::memory_order_release);
+                        doorbell.notify_one();
+                        return true;
+                    }
+                } else if (dif < 0) {
+                    return false;
+                } else {
+                    pos = head.load(std::memory_order_relaxed);
+                }
+            }
+        }
+        bool try_pop(T& out)
+            noexcept(std::is_nothrow_move_assignable_v<T> &&
+                     std::is_nothrow_move_constructible_v<T>)
+        {
+            std::size_t pos = tail.load(std::memory_order_relaxed);
+            while (true) {
+                auto& cell      = buffer[pos & mask];
+                const auto cseq = cell.seq.load(std::memory_order_acquire);
+                const auto dif  = static_cast<std::ptrdiff_t>(cseq) -
+                                  static_cast<std::ptrdiff_t>(pos + 1);
+                if (dif == 0) {
+                    if (tail.compare_exchange_weak(pos, pos + 1,
+                            std::memory_order_relaxed, std::memory_order_relaxed)) {
+                        out = std::move(*cell.slot.ptr());
+                        cell.slot.destroy();
+                        cell.seq.store(pos + capacity_pow2, std::memory_order_release);
+                        return true;
+                    }
+                } else if (dif < 0) {
+                    return false;
+                } else {
+                    pos = tail.load(std::memory_order_relaxed);
+                }
+            }
+        }
+        bool wait_pop(T& out, std::stop_token st)
+            noexcept(std::is_nothrow_move_assignable_v<T> &&
+                     std::is_nothrow_move_constructible_v<T>)
+        {
+            std::stop_callback on_stop(st, [this]() noexcept { notify_all(); });
+            auto last = sequence();
+            while (!st.stop_requested()) {
+                if (try_pop(out)) return true;
+                if (!wait_for_data(st, last)) return false;
+            }
+            return false;
+        }
+        std::uint32_t sequence() const noexcept {
+            return doorbell.load(std::memory_order_acquire);
+        }
+        void notify_all() noexcept {
+            doorbell.fetch_add(1, std::memory_order_release);
+            doorbell.notify_all();
+        }
+        bool wait_for_data(std::stop_token st, std::uint32_t& last) const noexcept {
+            if (st.stop_requested()) return false;
+            if (doorbell.load(std::memory_order_acquire) != last) return true;
+            doorbell.wait(last, std::memory_order_acquire);
+            last = doorbell.load(std::memory_order_acquire);
+            return !st.stop_requested();
+        }
+
+        static constexpr std::size_t capacity_pow2 = impl::ceil_pow2(capacity);
+        static_assert(capacity_pow2 >= 2, "capacity must be >= 2");
+        static constexpr std::size_t mask = capacity_pow2 - 1;
+
+        alignas(cache_line_t::value) std::atomic<std::size_t>  head{0};
+        alignas(cache_line_t::value) std::atomic<std::size_t>  tail{0};
+        alignas(cache_line_t::value) std::atomic<std::uint32_t> doorbell{0};
+        std::array<impl::cell_t<T>, capacity_pow2> buffer;
+    };
+
+} // namespace bounded::mpmc
+
+// ============================================================================
+// bounded::ring — byte-arena ring buffer on top of any queue_t
+//
+// Producer: push(data, length, type) — copies bytes into arena, posts ctrl_t
+// Consumer: pop() → ctrl_t;  data(ctrl_t) → const byte*;  release(ctrl_t)
+//
+// Single-producer assumption: head_ is not protected by a CAS. The inner
+// queue_t may be SPSC or MPSC depending on the ctrl slot concurrency needed.
+// ============================================================================
+namespace bounded::ring {
+
+    struct ctrl_t {
+        uint16_t type;
+        uint16_t length;
+        uint32_t position;
+    };
+    static_assert(sizeof(ctrl_t) == 8);
+
+    constexpr uint32_t align_up(uint32_t x, uint32_t a) noexcept {
+        return (x + (a - 1u)) & ~(a - 1u);
+    }
+
+    template<typename queue_t, std::size_t n_bytes_v, uint32_t align_v = 16>
+    class adaptor_t {
+    public:
+        static_assert((n_bytes_v & (n_bytes_v - 1)) == 0,
+            "n_bytes_v must be a power of two");
+
+        adaptor_t() = default;
+        explicit adaptor_t(queue_t q) : queue_(std::move(q)) {}
+
+        bool push(const void* data, uint32_t length, uint16_t type) noexcept {
+            if (!data || length == 0 || length > 0xFFFFu) return false;
+            uint32_t pos   = 0;
+            std::byte* dst = nullptr;
+            if (!try_reserve(length, pos, dst)) return false;
+            std::memcpy(dst, data, length);
+            return queue_.push(ctrl_t{type, static_cast<uint16_t>(length), pos});
+        }
+
+        std::optional<ctrl_t> pop() noexcept {
+            ctrl_t token;
+            if (!queue_.pop(token)) return std::nullopt;
+            return token;
+        }
+
+        const std::byte* data(const ctrl_t& c) const noexcept {
+            return buffer_.data() + c.position;
+        }
+
+        void release(const ctrl_t& c) noexcept {
+            tail_.store(tail_.load(std::memory_order_relaxed) + c.length,
+                        std::memory_order_release);
+        }
+
+        uint32_t    capacity()    const noexcept { return static_cast<uint32_t>(n_bytes_v); }
+        std::size_t approx_size() const noexcept { return queue_.approx_size(); }
+
+    private:
+        bool try_reserve(uint32_t length, uint32_t& out_pos, std::byte*& out_ptr) noexcept {
+            const uint32_t head     = head_.load(std::memory_order_relaxed);
+            const uint32_t tail     = tail_.load(std::memory_order_acquire);
+            const uint32_t used     = head - tail;
+            const uint32_t free_    = static_cast<uint32_t>(n_bytes_v) - used;
+            const uint32_t ahead    = align_up(head, align_v);
+            const uint32_t pad_aln  = ahead - head;
+            if (free_ < pad_aln + length) return false;
+
+            const uint32_t mask = static_cast<uint32_t>(n_bytes_v - 1);
+            uint32_t pos        = ahead & mask;
+            if (pos + length > n_bytes_v) {
+                const uint32_t tail_room = static_cast<uint32_t>(n_bytes_v) - pos;
+                if (free_ < pad_aln + tail_room + length) return false;
+                if (!queue_.push(ctrl_t{0u, static_cast<uint16_t>(tail_room), pos}))
+                    return false;
+                head_.store(ahead + tail_room, std::memory_order_release);
+                return try_reserve(length, out_pos, out_ptr);
+            }
+            out_pos = pos;
+            out_ptr = buffer_.data() + pos;
+            head_.store(ahead + length, std::memory_order_release);
+            return true;
+        }
+
+        queue_t                                    queue_{};
+        std::atomic<uint32_t>                      head_{0}, tail_{0};
+        alignas(64) std::array<std::byte, n_bytes_v> buffer_{};
+    };
+
+    // Convenience aliases
+    template<std::size_t ctrl_cap, std::size_t ring_bytes>
+    using spsc_t = adaptor_t<bounded::spsc::queue_t<ctrl_t, ctrl_cap>, ring_bytes>;
+
+    template<std::size_t ctrl_cap, std::size_t ring_bytes>
+    using mpsc_t = adaptor_t<bounded::mpsc::queue_t<ctrl_t, ctrl_cap>, ring_bytes>;
+
+} // namespace bounded::ring
+
+// ============================================================================
+// h5::impl — h5cpp-scoped aliases and thread-topology selector
+// ============================================================================
+namespace h5::impl {
+
+    template<typename T, std::size_t N>
+    using spsc_queue_t = bounded::spsc::queue_t<T, N>;
+
+    template<typename T, std::size_t N>
+    using mpsc_queue_t = bounded::mpsc::queue_t<T, N>;
+
+    template<typename T, std::size_t N>
+    using spmc_queue_t = bounded::spmc::queue_t<T, N>;
+
+    template<typename T, std::size_t N>
+    using mpmc_queue_t = bounded::mpmc::queue_t<T, N>;
+
+    template<std::size_t ctrl_cap, std::size_t ring_bytes>
+    using ring_spsc_t = bounded::ring::spsc_t<ctrl_cap, ring_bytes>;
+
+    template<std::size_t ctrl_cap, std::size_t ring_bytes>
+    using ring_mpsc_t = bounded::ring::mpsc_t<ctrl_cap, ring_bytes>;
+
+    // Select queue topology from producer/consumer counts.
+    // NP == 1 && NC == 1 → spsc (no CAS on either side)
+    // NP  > 1 && NC == 1 → mpsc (CAS on producer head)
+    // All other combinations fall back to mpsc (consumer always single in h5cpp).
+    template<std::size_t NP, std::size_t NC,
+             std::size_t ctrl_cap, std::size_t ring_bytes>
+    using staging_ring_t = std::conditional_t<
+        (NP == 1 && NC == 1),
+        bounded::ring::spsc_t<ctrl_cap, ring_bytes>,
+        bounded::ring::mpsc_t<ctrl_cap, ring_bytes>>;
+
+} // namespace h5::impl

--- a/h5cpp/core
+++ b/h5cpp/core
@@ -53,6 +53,7 @@
 	#include "H5Iall.hpp" /* base hid_t type definitions */
 	#include "H5Tall.hpp"
 	#include "H5Zall.hpp"
+	#include "H5Qall.hpp"
 	#include "H5Pall.hpp"
 	#include "H5Zpipeline.hpp"
 	#include "H5Zpipeline_basic.hpp"

--- a/h5cpp/io
+++ b/h5cpp/io
@@ -21,8 +21,6 @@
 	#include "H5Awrite.hpp"
 	#include "H5Aread.hpp"
 
-	#if __cplusplus >= 202002L
 	#include "H5Dranges.hpp"
-	#endif
-#endif	
+#endif
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -36,7 +36,7 @@ function(add_test_case file_name)
     add_executable(${test_name} ${file_name}.cpp)
 
     set_target_properties(${test_name} PROPERTIES
-        CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON CXX_EXTENSIONS OFF RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+        CXX_STANDARD 20 CXX_STANDARD_REQUIRED ON CXX_EXTENSIONS OFF RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
     target_include_directories(${test_name} PRIVATE ${INCLUDE_DIRS})
     target_link_libraries(${test_name} PRIVATE ${LIBS})
 
@@ -126,7 +126,7 @@ add_subdirectory(examples)
 # ---------------------------------------------------------------------------
 add_executable(test-win_stack_probe win_stack_probe.cpp)
 set_target_properties(test-win_stack_probe PROPERTIES
-    CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON CXX_EXTENSIONS OFF
+    CXX_STANDARD 20 CXX_STANDARD_REQUIRED ON CXX_EXTENSIONS OFF
     RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 target_include_directories(test-win_stack_probe PRIVATE ${INCLUDE_DIRS})
 # Intentionally do NOT link libdoctest — keep the call chain pristine.
@@ -144,7 +144,7 @@ if(WIN32)
         set(test_name test-win-lifecycle-${name})
         add_executable(${test_name} win_hdf5_lifecycle_probe.cpp)
         set_target_properties(${test_name} PROPERTIES
-            CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON CXX_EXTENSIONS OFF
+            CXX_STANDARD 20 CXX_STANDARD_REQUIRED ON CXX_EXTENSIONS OFF
             RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
         target_compile_definitions(${test_name} PRIVATE H5CPP_WIN_PROBE_MODE=${mode})
         target_include_directories(${test_name} PRIVATE ${INCLUDE_DIRS})
@@ -168,7 +168,7 @@ if(WIN32)
         set(test_name test-win-write-path-${name})
         add_executable(${test_name} win_h5dwrite_path_probe.cpp)
         set_target_properties(${test_name} PROPERTIES
-            CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON CXX_EXTENSIONS OFF
+            CXX_STANDARD 20 CXX_STANDARD_REQUIRED ON CXX_EXTENSIONS OFF
             RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
         target_compile_definitions(${test_name} PRIVATE H5CPP_WIN_WRITE_PROBE_MODE=${mode})
         target_include_directories(${test_name} PRIVATE ${INCLUDE_DIRS})
@@ -193,7 +193,7 @@ if(WIN32)
         set(test_name test-win-dapl-${name})
         add_executable(${test_name} win_dapl_probe.cpp)
         set_target_properties(${test_name} PROPERTIES
-            CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON CXX_EXTENSIONS OFF
+            CXX_STANDARD 20 CXX_STANDARD_REQUIRED ON CXX_EXTENSIONS OFF
             RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
         target_compile_definitions(${test_name} PRIVATE H5CPP_WIN_DAPL_PROBE_MODE=${mode})
         target_include_directories(${test_name} PRIVATE ${INCLUDE_DIRS})

--- a/test/examples/CMakeLists.txt
+++ b/test/examples/CMakeLists.txt
@@ -12,7 +12,7 @@ function(add_example_test file_name)
     set(test_name example-test-${file_name})
     add_executable(${test_name} ${file_name}.cpp)
     set_target_properties(${test_name} PROPERTIES
-        CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON CXX_EXTENSIONS OFF RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
+        CXX_STANDARD 20 CXX_STANDARD_REQUIRED ON CXX_EXTENSIONS OFF RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
     target_include_directories(${test_name} PRIVATE ${INCLUDE_DIRS})
     target_link_libraries(${test_name} PRIVATE ${LIBS})
 
@@ -41,13 +41,17 @@ add_example_test(test_arma_io     LIBRARIES libarmadillo)
 add_example_test(test_blaze_io    LIBRARIES libblaze)
 add_example_test(test_dlib_io     LIBRARIES libdlib)
 
-# ublas headers are vendored but rely on system Boost config/compiler headers
-# (the vendored copy only includes gcc.hpp, not clang.hpp or msvc.hpp)
-find_path(H5CPP_BOOST_CONFIG_INCLUDE NAMES boost/config.hpp)
-if(H5CPP_BOOST_CONFIG_INCLUDE)
-    add_example_test(test_ublas_io LIBRARIES libublas)
+# ublas v1.74 uses std::allocator::construct which was removed in C++20.
+# Skip the ublas test under C++20 builds.
+if(CMAKE_CXX_STANDARD LESS 20)
+    find_path(H5CPP_BOOST_CONFIG_INCLUDE NAMES boost/config.hpp)
+    if(H5CPP_BOOST_CONFIG_INCLUDE)
+        add_example_test(test_ublas_io LIBRARIES libublas)
+    else()
+        message(STATUS "Boost config headers not found — skipping test_ublas_io")
+    endif()
 else()
-    message(STATUS "Boost config headers not found — skipping test_ublas_io")
+    message(STATUS "C++20 build — skipping test_ublas_io (ublas v1.74 requires std::allocator::construct, removed in C++20)")
 endif()
 
 add_example_test(test_blitz_io    LIBRARIES libblitz)

--- a/thirdparty/dlib/v19.24/CMakeLists.txt
+++ b/thirdparty/dlib/v19.24/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 project(dlib_project)
 

--- a/thirdparty/dlib/v19.24/dlib/CMakeLists.txt
+++ b/thirdparty/dlib/v19.24/dlib/CMakeLists.txt
@@ -4,7 +4,7 @@
 #
 
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 set(CMAKE_DISABLE_SOURCE_CHANGES ON)
 set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)

--- a/thirdparty/dlib/v19.24/dlib/cmake
+++ b/thirdparty/dlib/v19.24/dlib/cmake
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR} dlib_build)
 

--- a/thirdparty/dlib/v19.24/dlib/cmake_utils/add_global_compiler_switch.cmake
+++ b/thirdparty/dlib/v19.24/dlib/cmake_utils/add_global_compiler_switch.cmake
@@ -1,6 +1,6 @@
 
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 message(WARNING "add_global_compiler_switch() is deprecated.  Use target_compile_options() instead")
 

--- a/thirdparty/dlib/v19.24/dlib/cmake_utils/check_if_avx_instructions_executable_on_host.cmake
+++ b/thirdparty/dlib/v19.24/dlib/cmake_utils/check_if_avx_instructions_executable_on_host.cmake
@@ -1,6 +1,6 @@
 # This script checks if your compiler and host processor can generate and then run programs with AVX instructions.
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 # Don't rerun this script if its already been executed.
 if (DEFINED AVX_IS_AVAILABLE_ON_HOST)

--- a/thirdparty/dlib/v19.24/dlib/cmake_utils/check_if_neon_available.cmake
+++ b/thirdparty/dlib/v19.24/dlib/cmake_utils/check_if_neon_available.cmake
@@ -1,6 +1,6 @@
 # This script checks if __ARM_NEON__ is defined for your compiler
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 # Don't rerun this script if its already been executed.
 if (DEFINED ARM_NEON_IS_AVAILABLE)

--- a/thirdparty/dlib/v19.24/dlib/cmake_utils/check_if_sse4_instructions_executable_on_host.cmake
+++ b/thirdparty/dlib/v19.24/dlib/cmake_utils/check_if_sse4_instructions_executable_on_host.cmake
@@ -1,6 +1,6 @@
 # This script checks if your compiler and host processor can generate and then run programs with SSE4 instructions.
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 # Don't rerun this script if its already been executed.
 if (DEFINED SSE4_IS_AVAILABLE_ON_HOST)

--- a/thirdparty/dlib/v19.24/dlib/cmake_utils/find_libjpeg.cmake
+++ b/thirdparty/dlib/v19.24/dlib/cmake_utils/find_libjpeg.cmake
@@ -1,7 +1,7 @@
 #This script just runs CMake's built in JPEG finding tool.  But it also checks that the
 #copy of libjpeg that cmake finds actually builds and links.
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 if (BUILDING_PYTHON_IN_MSVC)
    # Never use any system copy of libjpeg when building python in visual studio

--- a/thirdparty/dlib/v19.24/dlib/cmake_utils/find_libpng.cmake
+++ b/thirdparty/dlib/v19.24/dlib/cmake_utils/find_libpng.cmake
@@ -1,7 +1,7 @@
 #This script just runs CMake's built in PNG finding tool.  But it also checks that the
 #copy of libpng that cmake finds actually builds and links.
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 if (BUILDING_PYTHON_IN_MSVC)
    # Never use any system copy of libpng when building python in visual studio

--- a/thirdparty/dlib/v19.24/dlib/cmake_utils/set_compiler_specific_options.cmake
+++ b/thirdparty/dlib/v19.24/dlib/cmake_utils/set_compiler_specific_options.cmake
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 if (POLICY CMP0054)
    cmake_policy(SET CMP0054 NEW)

--- a/thirdparty/dlib/v19.24/dlib/cmake_utils/tell_visual_studio_to_use_static_runtime.cmake
+++ b/thirdparty/dlib/v19.24/dlib/cmake_utils/tell_visual_studio_to_use_static_runtime.cmake
@@ -2,7 +2,7 @@
 # Including this cmake script into your cmake project will cause visual studio
 # to build your project against the static C runtime.
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 if (POLICY CMP0054)
    cmake_policy(SET CMP0054 NEW)
 endif()

--- a/thirdparty/dlib/v19.24/dlib/cmake_utils/test_for_avx/CMakeLists.txt
+++ b/thirdparty/dlib/v19.24/dlib/cmake_utils/test_for_avx/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 project(avx_test)
 
 set(USE_AVX_INSTRUCTIONS ON CACHE BOOL "Use AVX instructions")

--- a/thirdparty/dlib/v19.24/dlib/cmake_utils/test_for_cpp11/CMakeLists.txt
+++ b/thirdparty/dlib/v19.24/dlib/cmake_utils/test_for_cpp11/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 project(cpp11_test)
 
 # Try to enable C++11

--- a/thirdparty/dlib/v19.24/dlib/cmake_utils/test_for_cuda/CMakeLists.txt
+++ b/thirdparty/dlib/v19.24/dlib/cmake_utils/test_for_cuda/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 project(cuda_test)
 
 include_directories(../../cuda)

--- a/thirdparty/dlib/v19.24/dlib/cmake_utils/test_for_cudnn/CMakeLists.txt
+++ b/thirdparty/dlib/v19.24/dlib/cmake_utils/test_for_cudnn/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 project(cudnn_test)
 include(../use_cpp_11.cmake)
 

--- a/thirdparty/dlib/v19.24/dlib/cmake_utils/test_for_libjpeg/CMakeLists.txt
+++ b/thirdparty/dlib/v19.24/dlib/cmake_utils/test_for_libjpeg/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 project(test_if_libjpeg_is_broken)
 
 find_package(JPEG)

--- a/thirdparty/dlib/v19.24/dlib/cmake_utils/test_for_libpng/CMakeLists.txt
+++ b/thirdparty/dlib/v19.24/dlib/cmake_utils/test_for_libpng/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 project(test_if_libpng_is_broken)
 
 find_package(PNG)

--- a/thirdparty/dlib/v19.24/dlib/cmake_utils/test_for_neon/CMakeLists.txt
+++ b/thirdparty/dlib/v19.24/dlib/cmake_utils/test_for_neon/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 project(neon_test)
 
 add_library(neon_test STATIC neon_test.cpp )

--- a/thirdparty/dlib/v19.24/dlib/cmake_utils/test_for_sse4/CMakeLists.txt
+++ b/thirdparty/dlib/v19.24/dlib/cmake_utils/test_for_sse4/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 project(sse4_test)
 
 set(USE_SSE4_INSTRUCTIONS ON CACHE BOOL "Use SSE4 instructions")

--- a/thirdparty/dlib/v19.24/dlib/cmake_utils/use_cpp_11.cmake
+++ b/thirdparty/dlib/v19.24/dlib/cmake_utils/use_cpp_11.cmake
@@ -2,7 +2,7 @@
 # compiler has C++11 support and enables it if it does.
 
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 if (POLICY CMP0054)
    cmake_policy(SET CMP0054 NEW)

--- a/thirdparty/dlib/v19.24/dlib/external/cblas/CMakeLists.txt
+++ b/thirdparty/dlib/v19.24/dlib/external/cblas/CMakeLists.txt
@@ -4,7 +4,7 @@
 #
 
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 project(cblas)
 
 

--- a/thirdparty/dlib/v19.24/dlib/external/pybind11/CMakeLists.txt
+++ b/thirdparty/dlib/v19.24/dlib/external/pybind11/CMakeLists.txt
@@ -5,7 +5,7 @@
 # All rights reserved. Use of this source code is governed by a
 # BSD-style license that can be found in the LICENSE file.
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 if (POLICY CMP0048)
   # cmake warns if loaded from a min-3.0-required parent dir, so silence the warning:

--- a/thirdparty/dlib/v19.24/dlib/external/pybind11/tools/pybind11Tools.cmake
+++ b/thirdparty/dlib/v19.24/dlib/external/pybind11/tools/pybind11Tools.cmake
@@ -5,7 +5,7 @@
 # All rights reserved. Use of this source code is governed by a
 # BSD-style license that can be found in the LICENSE file.
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 # Add a CMake parameter for choosing a desired Python version
 if(NOT PYBIND11_PYTHON_VERSION)

--- a/thirdparty/dlib/v19.24/dlib/matlab/CMakeLists.txt
+++ b/thirdparty/dlib/v19.24/dlib/matlab/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 PROJECT(mex_functions)
 

--- a/thirdparty/dlib/v19.24/dlib/matlab/cmake_mex_wrapper
+++ b/thirdparty/dlib/v19.24/dlib/matlab/cmake_mex_wrapper
@@ -3,7 +3,7 @@
 # that additional library dependencies can be added like this: add_mex_function(name lib1 dlib libetc).
 # That is, just add more libraries after the name and they will be build into the mex file.
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 set(BUILDING_MATLAB_MEX_FILE true)
 set(CMAKE_POSITION_INDEPENDENT_CODE True)

--- a/thirdparty/dlib/v19.24/dlib/test/CMakeLists.txt
+++ b/thirdparty/dlib/v19.24/dlib/test/CMakeLists.txt
@@ -3,7 +3,7 @@
 # information about it at http://www.cmake.org
 #
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 # create a variable called target_name and set it to the string "dtest"
 set (target_name dtest)

--- a/thirdparty/dlib/v19.24/dlib/test/blas_bindings/CMakeLists.txt
+++ b/thirdparty/dlib/v19.24/dlib/test/blas_bindings/CMakeLists.txt
@@ -3,7 +3,7 @@
 # information about it at http://www.cmake.org
 #
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 # This variable contains a list of all the tests we are building
 # into the regression test suite.

--- a/thirdparty/dlib/v19.24/dlib/test/tools/CMakeLists.txt
+++ b/thirdparty/dlib/v19.24/dlib/test/tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 add_subdirectory(../../../tools/imglab imglab_build)
 add_subdirectory(../../../tools/htmlify htmlify_build)

--- a/thirdparty/dlib/v19.24/examples/CMakeLists.txt
+++ b/thirdparty/dlib/v19.24/examples/CMakeLists.txt
@@ -32,7 +32,7 @@
 #
 
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 # Every project needs a name.  We call this the "examples" project.
 project(examples)
 

--- a/thirdparty/dlib/v19.24/tools/archive/CMakeLists.txt
+++ b/thirdparty/dlib/v19.24/tools/archive/CMakeLists.txt
@@ -4,7 +4,7 @@
 #
 
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 PROJECT(archive)
 
 

--- a/thirdparty/dlib/v19.24/tools/convert_dlib_nets_to_caffe/CMakeLists.txt
+++ b/thirdparty/dlib/v19.24/tools/convert_dlib_nets_to_caffe/CMakeLists.txt
@@ -3,7 +3,7 @@
 # information about it at http://www.cmake.org
 #
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 set (target_name dtoc)
 

--- a/thirdparty/dlib/v19.24/tools/htmlify/CMakeLists.txt
+++ b/thirdparty/dlib/v19.24/tools/htmlify/CMakeLists.txt
@@ -3,7 +3,7 @@
 # information about it at http://www.cmake.org
 #
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 # create a variable called target_name and set it to the string "htmlify"
 set (target_name htmlify)

--- a/thirdparty/dlib/v19.24/tools/imglab/CMakeLists.txt
+++ b/thirdparty/dlib/v19.24/tools/imglab/CMakeLists.txt
@@ -3,7 +3,7 @@
 # information about it at http://www.cmake.org
 #
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 # create a variable called target_name and set it to the string "imglab"
 set (target_name imglab)


### PR DESCRIPTION
## Summary

- `h5cpp/H5Qall.hpp`: new file — amalgamation of sigma `bounded::` queue and ring primitives under MIT license
  - `bounded::spsc::queue_t<T,N>` — power-of-2 ring, cache-line-aligned head/tail, `wait_pop(stop_token)`
  - `bounded::mpsc::queue_t<T,N>` — Vyukov CAS on head
  - `bounded::spmc::queue_t<T,N>` — single producer, CAS on tail for consumers
  - `bounded::mpmc::queue_t<T,N>` — full Vyukov, `try_push`/`try_pop`
  - `bounded::ring::adaptor_t<queue_t,N,align>` — byte-arena with `ctrl_t{type,length,position}`
  - `h5::impl::staging_ring_t<NP,NC,ctrl_cap,ring_bytes>` — selects `spsc_t` when NP=1∧NC=1, `mpsc_t` otherwise
  - Portability: `cache_line_size_v` uses `#ifdef __cpp_lib_hardware_interference_size` with GCC-only `-Winterference-size` pragma guard; falls back to 64 on clang-17/18
- `h5cpp/core`: `#include "H5Qall.hpp"` added after `H5Zall.hpp`
- C++20 infrastructure (mirrors #194 — needed because #195 was branched independently from staging):
  - `CMakeLists.txt`: `CMAKE_CXX_STANDARD 17→20`; `cxx_std_17→cxx_std_20`
  - CI coverage job: `CMAKE_CXX_STANDARD=17→20`
  - `h5cpp/io`: remove C++20 guard around `H5Dranges.hpp`
  - All test targets: `CXX_STANDARD 17→20`; ublas skipped under C++20
  - `thirdparty/dlib`: `cmake_minimum_required 2.8.12→3.5` (CMake 4.x compat)

## Test plan

- [x] Local build: clang++-20, C++20, Release — `cmake` configure clean
- [x] 45/45 tests pass (`ctest`)
- [ ] CI matrix: gcc-13/14, clang-17/18/19/20 (via GitHub Actions on merge)

Depends on #194 (should be merged first).
Closes #195