### PR TITLE
[#196]:svarga:feature, linear_value_dataset round-trip for iterator-only STL containers

### DIFF
--- a/h5cpp/H5Dread.hpp
+++ b/h5cpp/H5Dread.hpp
@@ -215,11 +215,26 @@ namespace h5 {
 			size.rank = count.rank;
 		}
 
-		T ref = impl::get<T>::ctor( count );
-		element_type *ptr = impl::data( ref );
-
-		::h5::read<element_type>(ds, ptr, count, args...);
-		return ref;
+		using traits = h5::meta::access_traits_t<T>;
+		constexpr auto kind = traits::kind;
+		if constexpr (kind == h5::meta::access_t::iterators) {
+			size_t n = 1;
+			for (int i = 0; i < size.rank; ++i) n *= size[i];
+			std::vector<element_type> flat(n);
+			::h5::read<element_type>(ds, flat.data(), count, args...);
+			if constexpr (std::is_same_v<T, std::forward_list<element_type>>) {
+				T result;
+				result.assign(flat.begin(), flat.end());
+				return result;
+			} else {
+				return T(flat.begin(), flat.end());
+			}
+		} else {
+			T ref = impl::get<T>::ctor( count );
+			element_type *ptr = impl::data( ref );
+			::h5::read<element_type>(ds, ptr, count, args...);
+			return ref;
+		}
 	}
 	/***************************  STRING *****************************/
  	/** \func_read_hdr

--- a/h5cpp/H5Mstl.hpp
+++ b/h5cpp/H5Mstl.hpp
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 #include <array>
+#include <forward_list>
 #include <initializer_list>
 #include <type_traits>
 #include "H5meta.hpp"    // for h5::meta::has_size, has_data, is_sequential_like
@@ -101,6 +102,12 @@ namespace h5::impl {
 	template <class T, class A> inline T* data( std::vector<T, A>& ref ){
 		return ref.data();
 	}
+	template <class T, std::size_t N> inline const T* data( const std::array<T,N>& ref ){
+		return ref.data();
+	}
+	template <class T, std::size_t N> inline T* data( std::array<T,N>& ref ){
+		return ref.data();
+	}
 	// vector<array<T,N>>: hand the buffer back as flat T* so the inner write/read
 	// path operates on N*M contiguous elements (POD layout makes this aliasing safe).
 	template <class T, std::size_t N, class A>
@@ -124,6 +131,10 @@ namespace h5::impl {
 		return {ref.size() * N};
 	}
 	template <class T> inline std::array<size_t,1> size( const std::initializer_list<T>& ref ){ return {ref.size()}; }
+	template <class T, class A>
+	inline std::array<size_t,1> size( const std::forward_list<T,A>& ref ){
+		return {static_cast<size_t>(std::distance(ref.begin(), ref.end()))};
+	}
 	// Gap 2: structural size() — containers with .size() not explicitly covered.
 	// Returns rank-1 extent for any non-scalar with a .size() member.
 	// The explicit vector<T,A> overload above is more specific and wins for vectors.

--- a/h5cpp/H5Tmeta.hpp
+++ b/h5cpp/H5Tmeta.hpp
@@ -708,7 +708,7 @@ namespace h5::meta {
             if constexpr (meta::has_size<T>::value)
                 return {static_cast<std::size_t>(c.size())};
             else
-                return {std::distance(c.begin(), c.end())};
+                return {static_cast<std::size_t>(std::distance(c.begin(), c.end()))};
         }
     };
 

--- a/test/H5Dio.cpp
+++ b/test/H5Dio.cpp
@@ -32,7 +32,9 @@ TEST_CASE_TEMPLATE_DEFINE("[#114] h5 round-trip", T, io_round_trip) {
     } else if constexpr (rep == sr_t::linear_value_dataset) {
         T obj{};
         h5::test::fill(obj, LOWER, UPPER, MIN_SZ, MAX_SZ);
-        if constexpr (std::is_same_v<T, std::vector<int>>) {
+        using access = h5::meta::access_traits_t<T>;
+        if constexpr (std::is_same_v<T, std::vector<int>>
+                   || access::kind == h5::meta::access_t::iterators) {
             h5::write(f.fd, type_name.c_str(), obj);
             auto readback = h5::read<T>(f.fd, type_name.c_str());
             CHECK(readback == obj);

--- a/thirdparty/dlib/v19.24/CMakeLists.txt
+++ b/thirdparty/dlib/v19.24/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 project(dlib_project)
 

--- a/thirdparty/dlib/v19.24/dlib/CMakeLists.txt
+++ b/thirdparty/dlib/v19.24/dlib/CMakeLists.txt
@@ -4,7 +4,7 @@
 #
 
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 set(CMAKE_DISABLE_SOURCE_CHANGES ON)
 set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)

--- a/thirdparty/dlib/v19.24/dlib/cmake
+++ b/thirdparty/dlib/v19.24/dlib/cmake
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 add_subdirectory(${CMAKE_CURRENT_LIST_DIR} dlib_build)
 

--- a/thirdparty/dlib/v19.24/dlib/cmake_utils/add_global_compiler_switch.cmake
+++ b/thirdparty/dlib/v19.24/dlib/cmake_utils/add_global_compiler_switch.cmake
@@ -1,6 +1,6 @@
 
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 message(WARNING "add_global_compiler_switch() is deprecated.  Use target_compile_options() instead")
 

--- a/thirdparty/dlib/v19.24/dlib/cmake_utils/check_if_avx_instructions_executable_on_host.cmake
+++ b/thirdparty/dlib/v19.24/dlib/cmake_utils/check_if_avx_instructions_executable_on_host.cmake
@@ -1,6 +1,6 @@
 # This script checks if your compiler and host processor can generate and then run programs with AVX instructions.
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 # Don't rerun this script if its already been executed.
 if (DEFINED AVX_IS_AVAILABLE_ON_HOST)

--- a/thirdparty/dlib/v19.24/dlib/cmake_utils/check_if_neon_available.cmake
+++ b/thirdparty/dlib/v19.24/dlib/cmake_utils/check_if_neon_available.cmake
@@ -1,6 +1,6 @@
 # This script checks if __ARM_NEON__ is defined for your compiler
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 # Don't rerun this script if its already been executed.
 if (DEFINED ARM_NEON_IS_AVAILABLE)

--- a/thirdparty/dlib/v19.24/dlib/cmake_utils/check_if_sse4_instructions_executable_on_host.cmake
+++ b/thirdparty/dlib/v19.24/dlib/cmake_utils/check_if_sse4_instructions_executable_on_host.cmake
@@ -1,6 +1,6 @@
 # This script checks if your compiler and host processor can generate and then run programs with SSE4 instructions.
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 # Don't rerun this script if its already been executed.
 if (DEFINED SSE4_IS_AVAILABLE_ON_HOST)

--- a/thirdparty/dlib/v19.24/dlib/cmake_utils/find_libjpeg.cmake
+++ b/thirdparty/dlib/v19.24/dlib/cmake_utils/find_libjpeg.cmake
@@ -1,7 +1,7 @@
 #This script just runs CMake's built in JPEG finding tool.  But it also checks that the
 #copy of libjpeg that cmake finds actually builds and links.
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 if (BUILDING_PYTHON_IN_MSVC)
    # Never use any system copy of libjpeg when building python in visual studio

--- a/thirdparty/dlib/v19.24/dlib/cmake_utils/find_libpng.cmake
+++ b/thirdparty/dlib/v19.24/dlib/cmake_utils/find_libpng.cmake
@@ -1,7 +1,7 @@
 #This script just runs CMake's built in PNG finding tool.  But it also checks that the
 #copy of libpng that cmake finds actually builds and links.
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 if (BUILDING_PYTHON_IN_MSVC)
    # Never use any system copy of libpng when building python in visual studio

--- a/thirdparty/dlib/v19.24/dlib/cmake_utils/set_compiler_specific_options.cmake
+++ b/thirdparty/dlib/v19.24/dlib/cmake_utils/set_compiler_specific_options.cmake
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 if (POLICY CMP0054)
    cmake_policy(SET CMP0054 NEW)

--- a/thirdparty/dlib/v19.24/dlib/cmake_utils/tell_visual_studio_to_use_static_runtime.cmake
+++ b/thirdparty/dlib/v19.24/dlib/cmake_utils/tell_visual_studio_to_use_static_runtime.cmake
@@ -2,7 +2,7 @@
 # Including this cmake script into your cmake project will cause visual studio
 # to build your project against the static C runtime.
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 if (POLICY CMP0054)
    cmake_policy(SET CMP0054 NEW)
 endif()

--- a/thirdparty/dlib/v19.24/dlib/cmake_utils/test_for_avx/CMakeLists.txt
+++ b/thirdparty/dlib/v19.24/dlib/cmake_utils/test_for_avx/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 project(avx_test)
 
 set(USE_AVX_INSTRUCTIONS ON CACHE BOOL "Use AVX instructions")

--- a/thirdparty/dlib/v19.24/dlib/cmake_utils/test_for_cpp11/CMakeLists.txt
+++ b/thirdparty/dlib/v19.24/dlib/cmake_utils/test_for_cpp11/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 project(cpp11_test)
 
 # Try to enable C++11

--- a/thirdparty/dlib/v19.24/dlib/cmake_utils/test_for_cuda/CMakeLists.txt
+++ b/thirdparty/dlib/v19.24/dlib/cmake_utils/test_for_cuda/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 project(cuda_test)
 
 include_directories(../../cuda)

--- a/thirdparty/dlib/v19.24/dlib/cmake_utils/test_for_cudnn/CMakeLists.txt
+++ b/thirdparty/dlib/v19.24/dlib/cmake_utils/test_for_cudnn/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 project(cudnn_test)
 include(../use_cpp_11.cmake)
 

--- a/thirdparty/dlib/v19.24/dlib/cmake_utils/test_for_libjpeg/CMakeLists.txt
+++ b/thirdparty/dlib/v19.24/dlib/cmake_utils/test_for_libjpeg/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 project(test_if_libjpeg_is_broken)
 
 find_package(JPEG)

--- a/thirdparty/dlib/v19.24/dlib/cmake_utils/test_for_libpng/CMakeLists.txt
+++ b/thirdparty/dlib/v19.24/dlib/cmake_utils/test_for_libpng/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 project(test_if_libpng_is_broken)
 
 find_package(PNG)

--- a/thirdparty/dlib/v19.24/dlib/cmake_utils/test_for_neon/CMakeLists.txt
+++ b/thirdparty/dlib/v19.24/dlib/cmake_utils/test_for_neon/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 project(neon_test)
 
 add_library(neon_test STATIC neon_test.cpp )

--- a/thirdparty/dlib/v19.24/dlib/cmake_utils/test_for_sse4/CMakeLists.txt
+++ b/thirdparty/dlib/v19.24/dlib/cmake_utils/test_for_sse4/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 project(sse4_test)
 
 set(USE_SSE4_INSTRUCTIONS ON CACHE BOOL "Use SSE4 instructions")

--- a/thirdparty/dlib/v19.24/dlib/cmake_utils/use_cpp_11.cmake
+++ b/thirdparty/dlib/v19.24/dlib/cmake_utils/use_cpp_11.cmake
@@ -2,7 +2,7 @@
 # compiler has C++11 support and enables it if it does.
 
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 if (POLICY CMP0054)
    cmake_policy(SET CMP0054 NEW)

--- a/thirdparty/dlib/v19.24/dlib/external/cblas/CMakeLists.txt
+++ b/thirdparty/dlib/v19.24/dlib/external/cblas/CMakeLists.txt
@@ -4,7 +4,7 @@
 #
 
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 project(cblas)
 
 

--- a/thirdparty/dlib/v19.24/dlib/external/pybind11/CMakeLists.txt
+++ b/thirdparty/dlib/v19.24/dlib/external/pybind11/CMakeLists.txt
@@ -5,7 +5,7 @@
 # All rights reserved. Use of this source code is governed by a
 # BSD-style license that can be found in the LICENSE file.
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 if (POLICY CMP0048)
   # cmake warns if loaded from a min-3.0-required parent dir, so silence the warning:

--- a/thirdparty/dlib/v19.24/dlib/external/pybind11/tools/pybind11Tools.cmake
+++ b/thirdparty/dlib/v19.24/dlib/external/pybind11/tools/pybind11Tools.cmake
@@ -5,7 +5,7 @@
 # All rights reserved. Use of this source code is governed by a
 # BSD-style license that can be found in the LICENSE file.
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 # Add a CMake parameter for choosing a desired Python version
 if(NOT PYBIND11_PYTHON_VERSION)

--- a/thirdparty/dlib/v19.24/dlib/matlab/CMakeLists.txt
+++ b/thirdparty/dlib/v19.24/dlib/matlab/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 PROJECT(mex_functions)
 

--- a/thirdparty/dlib/v19.24/dlib/matlab/cmake_mex_wrapper
+++ b/thirdparty/dlib/v19.24/dlib/matlab/cmake_mex_wrapper
@@ -3,7 +3,7 @@
 # that additional library dependencies can be added like this: add_mex_function(name lib1 dlib libetc).
 # That is, just add more libraries after the name and they will be build into the mex file.
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 set(BUILDING_MATLAB_MEX_FILE true)
 set(CMAKE_POSITION_INDEPENDENT_CODE True)

--- a/thirdparty/dlib/v19.24/dlib/test/CMakeLists.txt
+++ b/thirdparty/dlib/v19.24/dlib/test/CMakeLists.txt
@@ -3,7 +3,7 @@
 # information about it at http://www.cmake.org
 #
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 # create a variable called target_name and set it to the string "dtest"
 set (target_name dtest)

--- a/thirdparty/dlib/v19.24/dlib/test/blas_bindings/CMakeLists.txt
+++ b/thirdparty/dlib/v19.24/dlib/test/blas_bindings/CMakeLists.txt
@@ -3,7 +3,7 @@
 # information about it at http://www.cmake.org
 #
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 # This variable contains a list of all the tests we are building
 # into the regression test suite.

--- a/thirdparty/dlib/v19.24/dlib/test/tools/CMakeLists.txt
+++ b/thirdparty/dlib/v19.24/dlib/test/tools/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 add_subdirectory(../../../tools/imglab imglab_build)
 add_subdirectory(../../../tools/htmlify htmlify_build)

--- a/thirdparty/dlib/v19.24/examples/CMakeLists.txt
+++ b/thirdparty/dlib/v19.24/examples/CMakeLists.txt
@@ -32,7 +32,7 @@
 #
 
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 # Every project needs a name.  We call this the "examples" project.
 project(examples)
 

--- a/thirdparty/dlib/v19.24/tools/archive/CMakeLists.txt
+++ b/thirdparty/dlib/v19.24/tools/archive/CMakeLists.txt
@@ -4,7 +4,7 @@
 #
 
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 PROJECT(archive)
 
 

--- a/thirdparty/dlib/v19.24/tools/convert_dlib_nets_to_caffe/CMakeLists.txt
+++ b/thirdparty/dlib/v19.24/tools/convert_dlib_nets_to_caffe/CMakeLists.txt
@@ -3,7 +3,7 @@
 # information about it at http://www.cmake.org
 #
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 set (target_name dtoc)
 

--- a/thirdparty/dlib/v19.24/tools/htmlify/CMakeLists.txt
+++ b/thirdparty/dlib/v19.24/tools/htmlify/CMakeLists.txt
@@ -3,7 +3,7 @@
 # information about it at http://www.cmake.org
 #
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 # create a variable called target_name and set it to the string "htmlify"
 set (target_name htmlify)

--- a/thirdparty/dlib/v19.24/tools/imglab/CMakeLists.txt
+++ b/thirdparty/dlib/v19.24/tools/imglab/CMakeLists.txt
@@ -3,7 +3,7 @@
 # information about it at http://www.cmake.org
 #
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 
 # create a variable called target_name and set it to the string "imglab"
 set (target_name imglab)


### PR DESCRIPTION
## Summary

- `h5cpp/H5Mstl.hpp`: add `forward_list<T,A>` size overload (uses `std::distance`); add explicit `data(std::array<T,N>&)` / `data(const std::array<T,N>&)` overloads returning `T*`
- `h5cpp/H5Tmeta.hpp`: fix narrowing cast in `iterators` access_traits size fallback — `std::distance` returns `ptrdiff_t`, must cast to `size_t` for braced initializer
- `h5cpp/H5Dread.hpp`: add `access_t::iterators` dispatch in `read<T>(ds_t)` — reads into a flat `vector<element_t>`, then constructs `T` via range constructor; `forward_list` uses `assign(begin,end)`
- `test/H5Dio.cpp`: replace `linear_value_dataset` stub with live round-trips for `vector<int>` and all `access_t::iterators` types: `list`, `forward_list`, `deque`, `set`, `multiset`, `unordered_set`, `unordered_multiset`
- `thirdparty/dlib`: bump `cmake_minimum_required 2.8.12→3.5` (CMake 4.x compat)

`std::array<int,4>` retains its `WARN_MESSAGE` stub — the `impl::rank<array<T,N>> = 0` write path is a separate pre-existing issue.

## Test plan

- [x] Local build: clang++-20, C++17 staging base, Release — clean
- [x] 46/46 tests pass (`ctest`); `test-h5dio` exercises all 7 iterator-only types

Depends on #194 (C++20) for merge ordering.
Closes #196