### PR TITLE
[#193]:svarga:ci, add ASan and UBSan jobs with separate badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,10 +345,156 @@ jobs:
           name: status-${{ matrix.os }}-${{ matrix.compiler }}
           path: badge-status/status-${{ matrix.os }}-${{ matrix.compiler }}.json
 
+  asan:
+    name: asan / ubuntu-24.04 / clang-20
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+
+    concurrency:
+      group: asan-${{ github.ref }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          set -euxo pipefail
+          sudo apt-get update
+          sudo apt-get install -y cmake ninja-build wget gnupg lsb-release software-properties-common libhdf5-dev
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 20 all
+          echo "CC=$(command -v clang-20)" >> "$GITHUB_ENV"
+          echo "CXX=$(command -v clang++-20)" >> "$GITHUB_ENV"
+
+      - name: Configure
+        shell: bash
+        run: |
+          set -euxo pipefail
+          cmake -S . -B build -G Ninja \
+            -DCMAKE_C_COMPILER="$CC" \
+            -DCMAKE_CXX_COMPILER="$CXX" \
+            -DCMAKE_CXX_STANDARD=17 \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_C_FLAGS="-fsanitize=address -fno-omit-frame-pointer -O1 -g" \
+            -DCMAKE_CXX_FLAGS="-fsanitize=address -fno-omit-frame-pointer -O1 -g" \
+            -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address" \
+            -DH5CPP_BUILD_TESTS=ON
+
+      - name: Build
+        shell: bash
+        run: cmake --build build --parallel
+
+      - name: Test
+        shell: bash
+        env:
+          ASAN_OPTIONS: "detect_leaks=1:halt_on_error=1:abort_on_error=1:strict_string_checks=1"
+        run: ctest --test-dir build --output-on-failure
+
+      - name: Record Badge Status
+        if: always()
+        shell: bash
+        run: |
+          set -euxo pipefail
+          mkdir -p badge-status
+          cat <<EOF > badge-status/status-asan.json
+          {
+            "os": "ubuntu-24.04",
+            "compiler": "clang-20",
+            "label": "asan",
+            "status": "${{ job.status }}"
+          }
+          EOF
+
+      - name: Upload Status Artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: status-asan
+          path: badge-status/status-asan.json
+
+  ubsan:
+    name: ubsan / ubuntu-24.04 / clang-20
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+
+    concurrency:
+      group: ubsan-${{ github.ref }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          set -euxo pipefail
+          sudo apt-get update
+          sudo apt-get install -y cmake ninja-build wget gnupg lsb-release software-properties-common libhdf5-dev
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 20 all
+          echo "CC=$(command -v clang-20)" >> "$GITHUB_ENV"
+          echo "CXX=$(command -v clang++-20)" >> "$GITHUB_ENV"
+
+      - name: Configure
+        shell: bash
+        run: |
+          set -euxo pipefail
+          cmake -S . -B build -G Ninja \
+            -DCMAKE_C_COMPILER="$CC" \
+            -DCMAKE_CXX_COMPILER="$CXX" \
+            -DCMAKE_CXX_STANDARD=17 \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_C_FLAGS="-fsanitize=undefined -fno-sanitize-recover=undefined -fno-omit-frame-pointer -O1 -g" \
+            -DCMAKE_CXX_FLAGS="-fsanitize=undefined -fno-sanitize-recover=undefined -fno-omit-frame-pointer -O1 -g" \
+            -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=undefined" \
+            -DH5CPP_BUILD_TESTS=ON
+
+      - name: Build
+        shell: bash
+        run: cmake --build build --parallel
+
+      - name: Test
+        shell: bash
+        env:
+          UBSAN_OPTIONS: "print_stacktrace=1:halt_on_error=1"
+        run: ctest --test-dir build --output-on-failure
+
+      - name: Record Badge Status
+        if: always()
+        shell: bash
+        run: |
+          set -euxo pipefail
+          mkdir -p badge-status
+          cat <<EOF > badge-status/status-ubsan.json
+          {
+            "os": "ubuntu-24.04",
+            "compiler": "clang-20",
+            "label": "ubsan",
+            "status": "${{ job.status }}"
+          }
+          EOF
+
+      - name: Upload Status Artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: status-ubsan
+          path: badge-status/status-ubsan.json
+
   badge:
     name: Generate SVG Badges
     if: always()
-    needs: build
+    needs: [build, asan, ubsan]
     runs-on: ubuntu-24.04
 
     steps:
@@ -393,6 +539,7 @@ jobs:
             os=$(jq -r '.os' "$status_file")
             compiler=$(jq -r '.compiler' "$status_file")
             status=$(jq -r '.status' "$status_file")
+            custom_label=$(jq -r '.label // ""' "$status_file")
 
             prefix="unknown"
             symbol="%3F"
@@ -421,8 +568,13 @@ jobs:
                 ;;
             esac
 
-            label="${os}-${compiler}"
-            badge="$badge_dir/${label}.svg"
+            if [[ -n "$custom_label" ]]; then
+              badge_name="$custom_label"
+            else
+              badge_name="${os}-${compiler}"
+            fi
+
+            badge="$badge_dir/${badge_name}.svg"
             url="https://img.shields.io/badge/${prefix}-${symbol}-${color}.svg"
 
             echo "$url -> $badge"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 [![CI](https://github.com/vargalabs/h5cpp/actions/workflows/ci.yml/badge.svg)](https://github.com/vargalabs/h5cpp/actions/workflows/ci.yml)
+[![ASan](https://vargalabs.github.io/h5cpp/badges/asan.svg)](https://github.com/vargalabs/h5cpp/actions/workflows/ci.yml)
+[![UBSan](https://vargalabs.github.io/h5cpp/badges/ubsan.svg)](https://github.com/vargalabs/h5cpp/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/vargalabs/h5cpp/branch/release/graph/badge.svg)](https://app.codecov.io/gh/vargalabs/h5cpp/tree/release)
 [![MIT License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20123216.svg)](https://doi.org/10.5281/zenodo.20123216)

--- a/staging-build-matrix.md
+++ b/staging-build-matrix.md
@@ -1,5 +1,7 @@
 
 [![CI](https://github.com/vargalabs/h5cpp/actions/workflows/ci.yml/badge.svg)](https://github.com/vargalabs/h5cpp/actions/workflows/ci.yml)
+[![ASan](https://vargalabs.github.io/h5cpp/badges-staging/asan.svg)](https://github.com/vargalabs/h5cpp/actions/workflows/ci.yml)
+[![UBSan](https://vargalabs.github.io/h5cpp/badges-staging/ubsan.svg)](https://github.com/vargalabs/h5cpp/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/vargalabs/h5cpp/branch/staging/graph/badge.svg)](https://app.codecov.io/gh/vargalabs/h5cpp/tree/staging)
 [![MIT License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20123216.svg)](https://doi.org/10.5281/zenodo.20123216)


### PR DESCRIPTION
## Summary

- Adds `asan` job: `ubuntu-24.04` / `clang-20`, `Debug`, `-fsanitize=address -fno-omit-frame-pointer -O1 -g`, `ASAN_OPTIONS=detect_leaks=1:halt_on_error=1:abort_on_error=1:strict_string_checks=1`
- Adds `ubsan` job: same runner/compiler, `-fsanitize=undefined -fno-sanitize-recover=undefined`, `UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1`
- Updates `badge` job: `needs: [build, asan, ubsan]` so sanitizer results gate badge generation
- Updates badge generator to use optional `label` field in status JSON, falling back to `${os}-${compiler}` — sanitizer jobs emit `label: asan` / `label: ubsan`, producing `asan.svg` / `ubsan.svg`
- Adds `[![ASan]` and `[![UBSan]` badges to `README.md` (points at `badges/`) and `staging-build-matrix.md` (points at `badges-staging/`)

## Test plan

- [ ] Both `asan` and `ubsan` jobs appear in Actions UI on push
- [ ] `asan.svg` and `ubsan.svg` deployed to GitHub Pages after run
- [ ] Badges render in `README.md` and `staging-build-matrix.md`
- [ ] A deliberate UB or memory error in a test flips the corresponding badge red