### PR TITLE
[#76]:svarga:fix, Armadillo colmat size() returned {n_cols,n_rows} instead of {n_rows,n_cols}

### DIFF
--- a/h5cpp/H5Marma.hpp
+++ b/h5cpp/H5Marma.hpp
@@ -70,7 +70,7 @@ namespace h5::impl {
 	// determine rank and dimensions
 	template <class T> inline std::array<size_t,1> size( const h5::arma::rowvec<T>& ref ){ return {ref.n_elem};}
 	template <class T> inline std::array<size_t,1> size( const h5::arma::colvec<T>& ref ){ return {ref.n_elem};}
-	template <class T> inline std::array<size_t,2> size( const h5::arma::colmat<T>& ref ){ return {ref.n_cols,ref.n_rows};}
+	template <class T> inline std::array<size_t,2> size( const h5::arma::colmat<T>& ref ){ return {ref.n_rows,ref.n_cols};}
 	template <class T> inline std::array<size_t,3> size( const h5::arma::cube<T>& ref ){ return {ref.n_slices,ref.n_cols,ref.n_rows};}
 
 	// CTOR-s 

--- a/test/examples/test_arma_io.cpp
+++ b/test/examples/test_arma_io.cpp
@@ -12,10 +12,9 @@ TEST_CASE("[example] armadillo mat/vec round-trip") {
     const char* filename = "test_arma_io.h5";
     std::filesystem::remove(filename);
 
-    // BUILD and WRITE square matrix (avoids dimension transposition complexity)
-    arma::mat M(2, 2);
-    M(0, 0) = 1.0; M(0, 1) = 2.0;
-    M(1, 0) = 3.0; M(1, 1) = 4.0;
+    // BUILD and WRITE non-square matrix — shape (3 rows x 5 cols) catches row/col transposition bugs
+    arma::mat M = arma::linspace<arma::rowvec>(1.0, 15.0, 15);
+    M.reshape(3, 5);
 
     {
         h5::fd_t fd = h5::create(filename, H5F_ACC_TRUNC);


### PR DESCRIPTION
## Summary

- `H5Marma.hpp:73`: `size(arma::colmat)` returned `{ref.n_cols, ref.n_rows}` — swapped row/col order caused non-square matrices to round-trip with transposed shape
- Updated `test/examples/test_arma_io.cpp` to use a 3×5 non-square matrix so the bug (and the fix) are detectable; the previous 2×2 square test could not catch a row/col swap

## Test plan

- [ ] Build with Armadillo enabled
- [ ] Run `test_arma_io` — should pass with correct 3×5 shape and all 15 element values matching
- [ ] Confirm a 2×5 write reads back as 2×5 (not 5×2) in any HDF5 inspector (h5py, h5dump)

Closes #76