### PR TITLE
[#80]:svarga:fix, pt_t re-opens dataset with zero HDF5 chunk cache

### DIFF
--- a/h5cpp/H5Dappend.hpp
+++ b/h5cpp/H5Dappend.hpp
@@ -112,8 +112,20 @@ h5::pt_t::~pt_t(){
 inline
 void h5::pt_t::init( const h5::ds_t& handle ){
 	try {
-		ds = handle; // copy handle inc ref, behaves as unique_ptr
-		dt = h5::dt_t<void>{H5Dget_type(static_cast<hid_t>(handle))};
+		// Re-open with zero HDF5 chunk cache: the default DAPL allocates ~1MB per H5Dopen2
+		// call which accumulates in malloc arenas when pt_t is used in loops, even though
+		// the memory is logically freed on close.
+		hid_t raw = static_cast<hid_t>(handle);
+		hid_t fid = H5Iget_file_id(raw);
+		ssize_t nlen = H5Iget_name(raw, nullptr, 0);
+		std::vector<char> dname(static_cast<size_t>(nlen) + 1);
+		H5Iget_name(raw, dname.data(), dname.size());
+		hid_t dapl = H5Pcreate(H5P_DATASET_ACCESS);
+		H5Pset_chunk_cache(dapl, 0, 0, H5D_CHUNK_CACHE_W0_DEFAULT);
+		ds = h5::ds_t{H5Dopen2(fid, dname.data(), dapl)};
+		H5Pclose(dapl);
+		H5Fclose(fid);
+		dt = h5::dt_t<void>{H5Dget_type(static_cast<hid_t>(ds))};
 		h5::sp_t file_space = h5::get_space( handle );
 		rank = h5::get_simple_extent_dims( file_space, current_dims, nullptr );
 


### PR DESCRIPTION
## Summary

- `H5Dappend.hpp::init()`: replaced `ds = handle` (which copied an already-opened handle carrying the default ~1 MB HDF5 chunk cache) with a re-open via `H5Iget_file_id` + `H5Iget_name` + a new `H5P_DATASET_ACCESS` property list with `H5Pset_chunk_cache(dapl, 0, 0, ...)` before the rest of `init()` proceeds
- `pt_t` manages its own pipeline buffer; the HDF5 internal chunk cache is redundant and accumulates in malloc arenas under repeated open/append/close cycles, growing RSS visibly under `top` even though HDF5 does release the memory

## Test plan

- [ ] Build and run existing packet-table tests — no regressions expected
- [ ] Stress test: open/append/close pt_t in a tight loop (e.g. 10k iterations) and confirm RSS stays flat in `valgrind --tool=massif` or `/proc/self/status`

Closes #80