### PR TITLE
[#92]:svarga:refactor, apply minimal downstream updates to property/reference/file layers

### DIFF
--- a/h5cpp/H5Pall.hpp
+++ b/h5cpp/H5Pall.hpp
@@ -143,10 +143,6 @@ namespace h5::impl {
 	template <class capi, typename capi::fn_t capi_call, class T> using dcpl_tcall = tprop_t<h5::dcpl_t,default_dcpl, capi, capi_call, T>;
 }
 
-namespace h5::impl {
-	template <bool version, class capi, typename capi::fn_t capi_call  > 
-		using fapl_vcall = typename std::conditional<version, impl::fapl_call<capi,capi_call>,void>::type;
-}
 
 
 /** impl::property_group<H5Pset_property, args...> args... ::= all argument types except the first `this` hid_t prop_ID
@@ -281,10 +277,8 @@ using deflate                  = impl::dcpl_call< impl::dcpl_args<hid_t,unsigned
 using gzip                     = deflate;
 using fill_time                = impl::dcpl_call< impl::dcpl_args<hid_t,H5D_fill_time_t>,H5Pset_fill_time>;
 using alloc_time               = impl::dcpl_call< impl::dcpl_args<hid_t,H5D_alloc_time_t>,H5Pset_alloc_time>;
-using chunk_opts               = impl::dcpl_call< impl::dcpl_args<hid_t,unsigned>,H5Pset_chunk_opts>;
 template<class T> /*tcall ::= templated call with T*/
 using fill_value               = impl::dcpl_tcall< impl::dcpl_args<hid_t,hid_t,const void*>, H5Pset_fill_value, T>;
-using chunk                    = impl::dcpl_acall< impl::dcpl_args<hid_t,int,const hsize_t*>, H5Pset_chunk>; /*acall ::= array call of hsize_t */
 namespace flag{
 	using fletcher32           = impl::dcpl_call< impl::dcpl_args<hid_t>,H5Pset_fletcher32>;
 	using shuffle              = impl::dcpl_call< impl::dcpl_args<hid_t>,H5Pset_shuffle>;

--- a/h5cpp/H5Rregion.hpp
+++ b/h5cpp/H5Rregion.hpp
@@ -87,6 +87,7 @@ namespace h5::exp {
 		element_t *ptr = impl::data(object);
         h5::sp_t mem_space = h5::create_simple(block);
         h5::select_all(mem_space);
+        const h5::dxpl_t& dxpl = arg::get(h5::default_dxpl, args...);
 
         H5CPP_CHECK_NZ(
         H5Dread(ds_, mem_type, mem_space, file_space, dxpl, ptr ),


### PR DESCRIPTION
## Summary
- Removes `fapl_vcall` dead template alias from `H5Pall.hpp` (never referenced anywhere in the codebase)
- Removes unconditional duplicate `using chunk_opts` and `using chunk` that shadowed the version-guarded canonical definitions
- Adds missing `dxpl` declaration in `h5::exp::read` in `H5Rregion.hpp` before the `H5Dread` call where it was used undeclared

## Test plan
- [ ] Full test suite compiles and passes without behavior change (compile-time cleanup only)
- [ ] CI matrix green across HDF5 1.10 / 1.12 / 2.0 versions