### PR TITLE
[#205]:svarga:refactor, add C++17 fallback for threaded_pipeline_t via doorbell abstraction

### DIFF
--- a/h5cpp/H5Zpipeline_threaded.hpp
+++ b/h5cpp/H5Zpipeline_threaded.hpp
@@ -6,10 +6,16 @@
 #include <atomic>
 #include <cstring>
 #include <memory>
+#include <mutex>
+#include <queue>
 #include <thread>
 #include <vector>
 #include "H5Zpipeline.hpp"
-#include "H5Qall.hpp"
+#if __cplusplus >= 202002L
+#  include "H5Qall.hpp"
+#endif
+#include "detail/doorbell.hpp"
+#include "detail/stoppable_thread.hpp"
 
 // Workers handle compression only; H5Dwrite_chunk is always called from the
 // main thread.  Work items use raw ::hid_t integers (not h5cpp RAII wrappers)
@@ -52,6 +58,12 @@ namespace detail {
     };
 
 } // namespace detail
+
+#if __cplusplus >= 202002L
+// ============================================================================
+// C++20 path: uses bounded lock-free queues from H5Qall.hpp and std::jthread.
+// This block is byte-for-byte identical to the original implementation.
+// ============================================================================
 
 struct threaded_pipeline_t : public pipeline_t<threaded_pipeline_t> {
     threaded_pipeline_t() = default;
@@ -212,5 +224,245 @@ private:
     std::vector<std::jthread> workers_;
     std::once_flag            init_flag_;
 };
+
+#else
+// ============================================================================
+// C++17 fallback path: mutex-based queues + h5::detail::stoppable_thread_t.
+// ============================================================================
+
+namespace detail {
+
+    // Simple mutex-protected FIFO queue for C++17, signalled via doorbell_t.
+    // Replaces bounded::spmc and bounded::mpsc for the C++17 build.
+    template<typename T>
+    class c17_queue_t {
+    public:
+        c17_queue_t() = default;
+        c17_queue_t(const c17_queue_t&) = delete;
+        c17_queue_t& operator=(const c17_queue_t&) = delete;
+
+        // Non-blocking push — always succeeds (unbounded).
+        // Returns true for API compatibility with bounded queues.
+        bool push(T&& v) {
+            {
+                std::lock_guard<std::mutex> lk(m_);
+                q_.push(std::move(v));
+            }
+            bell_.ring();
+            return true;
+        }
+
+        // Non-blocking pop. Returns true if an item was retrieved.
+        bool pop(T& out) {
+            std::lock_guard<std::mutex> lk(m_);
+            if (q_.empty()) return false;
+            out = std::move(q_.front());
+            q_.pop();
+            return true;
+        }
+
+        // Blocking pop: waits until an item is available or stop is requested.
+        // Returns true if an item was retrieved, false if stop was requested.
+        bool wait_pop(T& out, h5::detail::stop_token_t st) {
+            while (!st.stop_requested()) {
+                {
+                    std::lock_guard<std::mutex> lk(m_);
+                    if (!q_.empty()) {
+                        out = std::move(q_.front());
+                        q_.pop();
+                        return true;
+                    }
+                }
+                const auto last = bell_.load();
+                // Recheck under lock before waiting to avoid missed wakeup.
+                {
+                    std::lock_guard<std::mutex> lk(m_);
+                    if (!q_.empty()) {
+                        out = std::move(q_.front());
+                        q_.pop();
+                        return true;
+                    }
+                }
+                if (!st.stop_requested())
+                    bell_.wait(last);
+            }
+            return false;
+        }
+
+        // Wake all waiters (used on shutdown to unblock wait_pop).
+        void notify_all() { bell_.ring_all(); }
+
+    private:
+        std::mutex              m_;
+        std::queue<T>           q_;
+        h5::detail::doorbell_t  bell_;
+    };
+
+} // namespace detail
+
+struct threaded_pipeline_t : public pipeline_t<threaded_pipeline_t> {
+    threaded_pipeline_t() = default;
+
+    ~threaded_pipeline_t() {
+        // Drain all in-flight chunks (workers compress, main thread writes).
+        flush();
+        // Notify workers so they observe stop and wake from wait_pop.
+        compress_queue_.notify_all();
+        // h5::detail::stoppable_thread_t dtors call request_stop() then join().
+    }
+
+    threaded_pipeline_t(const threaded_pipeline_t&) = delete;
+    threaded_pipeline_t& operator=(const threaded_pipeline_t&) = delete;
+    threaded_pipeline_t(threaded_pipeline_t&&) = delete;
+    threaded_pipeline_t& operator=(threaded_pipeline_t&&) = delete;
+
+    // Drains all in-flight work and calls H5Dwrite_chunk from the calling
+    // (main) thread.  Must be called before reading back written data.
+    void flush() {
+        while (in_flight_.load(std::memory_order_acquire) > 0) {
+            drain_done();
+            std::this_thread::yield();
+        }
+        drain_done(); // final sweep after counter hits zero
+    }
+
+    void write_chunk_impl(const hsize_t* offset, std::size_t nbytes, const void* ptr) {
+        ensure_workers();
+        drain_done(); // opportunistic: write any already-compressed chunks
+
+        detail::raw_work_t work;
+        work.data = std::make_unique<std::byte[]>(nbytes);
+        std::memcpy(work.data.get(), ptr, nbytes);
+        std::copy(offset, offset + this->rank, work.offset.data());
+        work.nbytes  = nbytes;
+        work.ds_id   = static_cast<::hid_t>(this->ds);
+        work.dxpl_id = static_cast<::hid_t>(this->dxpl);
+
+        in_flight_.fetch_add(1, std::memory_order_release);
+        while (!compress_queue_.push(std::move(work))) {
+            drain_done(); // relieve back-pressure
+            std::this_thread::yield();
+        }
+    }
+
+    void read_chunk_impl(const hsize_t* offset, std::size_t nbytes, void* /*ptr*/) {
+        uint32_t filter_mask;
+        std::size_t length = nbytes;
+        if (tail == 0) {
+#if H5_VERSION_GE(2,0,0)
+            std::size_t buf_size = nbytes;
+            H5Dread_chunk2(ds, dxpl, offset, &filter_mask, chunk0, &buf_size);
+#else
+            H5Dread_chunk(ds, dxpl, offset, &filter_mask, chunk0);
+#endif
+            return;
+        }
+        void* read_target = (tail % 2 == 1) ? chunk1 : chunk0;
+#if H5_VERSION_GE(2,0,0)
+        std::size_t buf_size = nbytes;
+        H5Dread_chunk2(ds, dxpl, offset, &filter_mask, read_target, &buf_size);
+#else
+        H5Dread_chunk(ds, dxpl, offset, &filter_mask, read_target);
+#endif
+        void* src = read_target;
+        void* dst = (read_target == chunk0)
+            ? static_cast<void*>(chunk1) : static_cast<void*>(chunk0);
+        for (hsize_t j = tail; j > 0; --j) {
+            const hsize_t fi = j - 1;
+            length = filter[fi](dst, src, length,
+                flags[fi] | H5Z_FLAG_REVERSE, cd_size[fi], cd_values[fi]);
+            void* tmp = src; src = dst; dst = tmp;
+        }
+    }
+
+private:
+    // Called from main thread only: pop finished compressed chunks and write.
+    void drain_done() {
+        detail::done_work_t result;
+        while (done_queue_.pop(result)) {
+            H5Dwrite_chunk(result.ds_id, result.dxpl_id, result.mask,
+                           result.offset.data(), result.nbytes, result.data.get());
+            in_flight_.fetch_sub(1, std::memory_order_release);
+        }
+    }
+
+    void ensure_workers() {
+        std::call_once(init_flag_, [this] {
+            constexpr unsigned cfg = static_cast<unsigned>(H5CPP_PIPELINE_WORKERS);
+            const unsigned n = (cfg > 0) ? cfg
+                                         : std::max(1u, std::thread::hardware_concurrency());
+            workers_.reserve(n);
+            for (unsigned i = 0; i < n; ++i)
+                workers_.emplace_back(
+                    [this](h5::detail::stop_token_t st) { worker_loop(st); });
+        });
+    }
+
+    void worker_loop(h5::detail::stop_token_t st) {
+        const std::size_t scratch = filter::filter_scratch_bound(block_size);
+        aligned_ptr wbuf0 = make_aligned(H5CPP_MEM_ALIGNMENT, scratch);
+        aligned_ptr wbuf1 = make_aligned(H5CPP_MEM_ALIGNMENT, scratch);
+
+        detail::raw_work_t work;
+        while (compress_queue_.wait_pop(work, st)) {
+            detail::done_work_t result = compress(work, wbuf0, wbuf1);
+            while (!done_queue_.push(std::move(result)))
+                std::this_thread::yield();
+        }
+    }
+
+    detail::done_work_t compress(const detail::raw_work_t& work,
+                                 aligned_ptr& wbuf0, aligned_ptr& wbuf1)
+    {
+        detail::done_work_t out;
+        out.offset  = work.offset;
+        out.ds_id   = work.ds_id;
+        out.dxpl_id = work.dxpl_id;
+
+        std::size_t length = work.nbytes;
+
+        if (tail == 0) {
+            // No filters: copy raw bytes into an aligned buffer.
+            const std::size_t sz = filter::filter_scratch_bound(length);
+            out.data  = make_aligned(H5CPP_MEM_ALIGNMENT, sz);
+            std::memcpy(out.data.get(), work.data.get(), length);
+            out.nbytes = length;
+            out.mask   = 0;
+            return out;
+        }
+
+        // First filter: work.data → wbuf0.
+        length = filter[0](wbuf0.get(), work.data.get(), length,
+                           flags[0], cd_size[0], cd_values[0]);
+        if (!length) out.mask |= 1u;
+
+        // Subsequent filters: ping-pong between wbuf0 and wbuf1.
+        void* src = wbuf0.get();
+        void* dst = wbuf1.get();
+        for (hsize_t j = 1; j < tail; ++j) {
+            length = filter[j](dst, src, length, flags[j], cd_size[j], cd_values[j]);
+            if (!length) out.mask |= (1u << j);
+            std::swap(src, dst);
+        }
+
+        // Copy filtered result into fresh aligned buffer so scratch is reusable.
+        const std::size_t sz = filter::filter_scratch_bound(length);
+        out.data = make_aligned(H5CPP_MEM_ALIGNMENT, sz);
+        std::memcpy(out.data.get(), src, length);
+        out.nbytes = length;
+        return out;
+    }
+
+    // compress_queue_: main thread pushes raw chunks; workers pop and compress.
+    detail::c17_queue_t<detail::raw_work_t>  compress_queue_;
+    // done_queue_:     workers push compressed chunks; main thread pops and writes.
+    detail::c17_queue_t<detail::done_work_t> done_queue_;
+
+    std::atomic<int>                              in_flight_{0};
+    std::vector<h5::detail::stoppable_thread_t>   workers_;
+    std::once_flag                                init_flag_;
+};
+
+#endif // __cplusplus >= 202002L
 
 } // namespace h5::impl

--- a/h5cpp/detail/doorbell.hpp
+++ b/h5cpp/detail/doorbell.hpp
@@ -1,0 +1,55 @@
+#pragma once
+// Doorbell: a sequenced wake primitive. C++20 uses atomic wait/notify
+// (lock-free, maps to OS futex). C++17 falls back to mutex+condvar.
+// API is the same either way.
+#include <cstdint>
+#ifdef __cpp_lib_atomic_wait
+#  include <atomic>
+namespace h5::detail {
+    struct doorbell_t {
+        void ring() noexcept {
+            seq_.fetch_add(1, std::memory_order_release);
+            seq_.notify_one();
+        }
+        void ring_all() noexcept {
+            seq_.fetch_add(1, std::memory_order_release);
+            seq_.notify_all();
+        }
+        void wait(std::uint32_t last) const noexcept {
+            seq_.wait(last, std::memory_order_acquire);
+        }
+        std::uint32_t load() const noexcept {
+            return seq_.load(std::memory_order_acquire);
+        }
+    private:
+        std::atomic<std::uint32_t> seq_{0};
+    };
+} // namespace h5::detail
+#else
+#  include <condition_variable>
+#  include <mutex>
+namespace h5::detail {
+    struct doorbell_t {
+        void ring() noexcept {
+            { std::lock_guard<std::mutex> lk(m_); ++seq_; }
+            cv_.notify_one();
+        }
+        void ring_all() noexcept {
+            { std::lock_guard<std::mutex> lk(m_); ++seq_; }
+            cv_.notify_all();
+        }
+        void wait(std::uint32_t last) {
+            std::unique_lock<std::mutex> lk(m_);
+            cv_.wait(lk, [&]{ return seq_ != last; });
+        }
+        std::uint32_t load() const noexcept {
+            std::lock_guard<std::mutex> lk(const_cast<std::mutex&>(m_));
+            return seq_;
+        }
+    private:
+        mutable std::mutex m_;
+        std::condition_variable cv_;
+        std::uint32_t seq_{0};
+    };
+} // namespace h5::detail
+#endif

--- a/h5cpp/detail/stoppable_thread.hpp
+++ b/h5cpp/detail/stoppable_thread.hpp
@@ -1,0 +1,66 @@
+#pragma once
+// stoppable_thread_t: a thread that supports cooperative cancellation.
+// C++20: thin alias over std::jthread (stop_token injected automatically).
+// C++17: std::thread wrapper with atomic stop flag; user lambda receives
+//        h5::detail::stop_token_t as first argument.
+#include <thread>
+#include <atomic>
+#include <functional>
+
+#ifdef __cpp_lib_jthread
+#  include <stop_token>
+namespace h5::detail {
+    using stop_token_t       = std::stop_token;
+    using stoppable_thread_t = std::jthread;
+} // namespace h5::detail
+
+#else
+namespace h5::detail {
+
+    class stop_token_t {
+        std::shared_ptr<std::atomic<bool>> flag_;
+        friend class stoppable_thread_t;
+        explicit stop_token_t(std::shared_ptr<std::atomic<bool>> f) noexcept
+            : flag_(std::move(f)) {}
+    public:
+        stop_token_t() = default;
+        [[nodiscard]] bool stop_requested() const noexcept {
+            return flag_ && flag_->load(std::memory_order_acquire);
+        }
+    };
+
+    class stoppable_thread_t {
+        std::shared_ptr<std::atomic<bool>> flag_ =
+            std::make_shared<std::atomic<bool>>(false);
+        std::thread t_;
+    public:
+        stoppable_thread_t() = default;
+
+        template<class Fn, class... Args>
+        explicit stoppable_thread_t(Fn&& fn, Args&&... args) {
+            stop_token_t st{flag_};
+            t_ = std::thread(std::forward<Fn>(fn), std::move(st),
+                             std::forward<Args>(args)...);
+        }
+
+        ~stoppable_thread_t() {
+            if (t_.joinable()) {
+                flag_->store(true, std::memory_order_release);
+                t_.join();
+            }
+        }
+
+        stoppable_thread_t(const stoppable_thread_t&) = delete;
+        stoppable_thread_t& operator=(const stoppable_thread_t&) = delete;
+        stoppable_thread_t(stoppable_thread_t&&) noexcept = default;
+        stoppable_thread_t& operator=(stoppable_thread_t&&) noexcept = default;
+
+        void request_stop() noexcept {
+            flag_->store(true, std::memory_order_release);
+        }
+        [[nodiscard]] bool joinable() const noexcept { return t_.joinable(); }
+        void join() { if (t_.joinable()) t_.join(); }
+    };
+
+} // namespace h5::detail
+#endif


### PR DESCRIPTION
## Summary
- Adds `h5cpp/detail/doorbell.hpp`: C++17-compatible wait/notify abstraction (C++20 path uses `atomic::wait/notify_one`; C++17 path uses `mutex` + `condition_variable`)
- Adds `h5cpp/detail/stoppable_thread.hpp`: C++17 fallback for `jthread`/`stop_token` (shared atomic flag + wrapper type)
- Wires `H5Zpipeline_threaded.hpp` onto these abstractions under `__cplusplus < 202002L`, keeping the C++20 path unchanged

## Test plan
- [ ] Build with `-DCMAKE_CXX_STANDARD=17` compiles without error
- [ ] Build with `-DCMAKE_CXX_STANDARD=20` still uses `std::jthread` and `atomic` wait/notify
- [ ] CI matrix green