### PR TITLE
[#218]:svarga:fix, remove duplicate impl::data() overloads for std::array<T,N> in H5Mstl.hpp

### DIFF
--- a/h5cpp/H5Mstl.hpp
+++ b/h5cpp/H5Mstl.hpp
@@ -118,16 +118,6 @@ namespace h5::impl {
 	inline T* data( std::vector<std::array<T,N>, A>& ref ){
 		return ref.empty() ? nullptr : ref.front().data();
 	}
-	// std::array<T,N>: return element pointer so I/O paths treat it as N
-	// contiguous T values rather than a single POD struct.
-	template <class T, std::size_t N>
-	inline const T* data( const std::array<T,N>& ref ){
-		return ref.data();
-	}
-	template <class T, std::size_t N>
-	inline T* data( std::array<T,N>& ref ){
-		return ref.data();
-	}
 	// std::array<T,N>: report size as {N} so the attribute/dataset is created
 	// with rank-1 extent N rather than rank-0 scalar (which is_scalar<> implies
 	// because std::array is standard_layout+trivial).


### PR DESCRIPTION
## Summary
- Removes the duplicate `impl::data(const std::array<T,N>&)` and `impl::data(std::array<T,N>&)` overloads added at lines 123–130 by PR #214 (#11); identical overloads already existed at lines 105–108
- Redefinition caused a build failure across all platforms and compilers on every TU including `h5cpp/all`

## Test plan
- [ ] Full build with `-DCMAKE_CXX_STANDARD=17 -DH5CPP_BUILD_TESTS=ON -DH5CPP_BUILD_EXAMPLES=ON` passes without error (verified locally)
- [ ] CI matrix green (Linux / macOS / Windows)