### PR TITLE
[#220]:svarga:fix, staging-build-matrix.md CI badge missing ?branch=staging query parameter

### DIFF
--- a/staging-build-matrix.md
+++ b/staging-build-matrix.md
@@ -1,5 +1,5 @@
 
-[![CI](https://github.com/vargalabs/h5cpp/actions/workflows/ci.yml/badge.svg)](https://github.com/vargalabs/h5cpp/actions/workflows/ci.yml)
+[![CI](https://github.com/vargalabs/h5cpp/actions/workflows/ci.yml/badge.svg?branch=staging)](https://github.com/vargalabs/h5cpp/actions/workflows/ci.yml)
 [![ASan](https://vargalabs.github.io/h5cpp/badges-staging/asan.svg)](https://github.com/vargalabs/h5cpp/actions/workflows/ci.yml)
 [![UBSan](https://vargalabs.github.io/h5cpp/badges-staging/ubsan.svg)](https://github.com/vargalabs/h5cpp/actions/workflows/ci.yml)
 [![codecov](https://codecov.io/gh/vargalabs/h5cpp/branch/staging/graph/badge.svg)](https://app.codecov.io/gh/vargalabs/h5cpp/tree/staging)


### PR DESCRIPTION
## Summary
- Appends `?branch=staging` to the CI badge image URL in `staging-build-matrix.md`; without it GitHub resolves to the most recent workflow run across all branches (typically `release`), so the staging doc page showed release CI status

## Test plan
- [ ] CI badge on staging-build-matrix.md reflects staging branch status after merge