### PR TITLE
[#228]:svarga:fix, H5Tfloat16.cpp missing main() on pre-C++23 builds causes link failure

### DIFF
--- a/test/H5Tfloat16.cpp
+++ b/test/H5Tfloat16.cpp
@@ -1,6 +1,7 @@
-#if __cplusplus >= 202302L && defined(__STDCPP_FLOAT16_T__)
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include <doctest/all>
+
+#if __cplusplus >= 202302L && defined(__STDCPP_FLOAT16_T__)
 #include <h5cpp/all>
 #include <stdfloat>
 #include <vector>
@@ -66,6 +67,4 @@ TEST_CASE("[#224] std::float16_t attribute write/read via h5::awrite/h5::aread")
     CHECK(static_cast<float>(read) == doctest::Approx(static_cast<float>(written)).epsilon(0.01));
 }
 
-#else
-// Empty compilation unit — pre-C++23 or compiler without __STDCPP_FLOAT16_T__
 #endif


### PR DESCRIPTION
## Summary

- `#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN` was inside the `#if __cplusplus >= 202302L && defined(__STDCPP_FLOAT16_T__)` guard
- On all pre-C++23 builds (clang-17, gcc-13, MSVC, Apple Clang) the guard fires false → empty translation unit → linker error: `undefined reference to 'main'`
- Fix: hoist `DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN` and `#include <doctest/all>` above the guard — doctest's generated `main()` is always present; `TEST_CASE` bodies remain gated and are simply absent when the guard is false (binary links and exits 0 with zero tests)

## Test plan

- [ ] Pre-C++23 builds (clang-17, gcc-13, MSVC, Apple Clang): `test-h5tfloat16` links and exits 0
- [ ] C++23 with `__STDCPP_FLOAT16_T__` (gcc-13+/clang-17+ x86): 3 test cases pass
- [ ] CI matrix fully green