### PR TITLE
[#204]:svarga:packaging, add unified installer pipeline: deb-dev/rpm-devel/NSIS/productbuild

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,182 @@
+name: Package
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: package-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # ── Linux (DEB + RPM) ────────────────────────────────────────────────────────
+  package-linux:
+    name: ${{ matrix.arch }} / DEB + RPM
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubuntu-22.04
+            deb_arch: amd64
+            rpm_arch: x86_64
+          - arch: arm64
+            runner: ubuntu-22.04-arm
+            deb_arch: arm64
+            rpm_arch: aarch64
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            libhdf5-dev rpm
+
+      - name: Configure
+        run: |
+          cmake -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX=/usr \
+            -DCPACK_PACKAGING_INSTALL_PREFIX=/usr \
+            -DH5CPP_BUILD_EXAMPLES=OFF \
+            -DH5CPP_BUILD_TESTS=OFF \
+            -DH5CPP_BUILD_BENCH=OFF
+
+      - name: Build (amalgamation only)
+        run: cmake --build build --target h5cpp-amalgamate
+
+      - name: Package DEB
+        run: cd build && cpack -G DEB
+        env:
+          CPACK_DEBIAN_PACKAGE_ARCHITECTURE: ${{ matrix.deb_arch }}
+
+      - name: Package RPM
+        run: cd build && cpack -G RPM
+        env:
+          CPACK_RPM_PACKAGE_ARCHITECTURE: ${{ matrix.rpm_arch }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: packages-linux-${{ matrix.arch }}
+          path: |
+            build/*.deb
+            build/*.rpm
+          if-no-files-found: error
+
+  # ── macOS (.pkg via productbuild) ────────────────────────────────────────────
+  package-macos:
+    name: macos-15 / arm64 / pkg
+    runs-on: macos-15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: brew install hdf5
+
+      - name: Configure
+        run: |
+          cmake -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX=/usr/local \
+            -DH5CPP_BUILD_EXAMPLES=OFF \
+            -DH5CPP_BUILD_TESTS=OFF \
+            -DH5CPP_BUILD_BENCH=OFF
+
+      - name: Build (amalgamation only)
+        run: cmake --build build --target h5cpp-amalgamate
+
+      - name: Package
+        run: cd build && cpack -G productbuild
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: packages-macos-arm64
+          path: build/*.pkg
+          if-no-files-found: error
+
+  # ── Windows (NSIS .exe) ───────────────────────────────────────────────────────
+  package-windows:
+    name: windows / x64 / NSIS
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache HDF5
+        id: cache-hdf5
+        uses: actions/cache@v4
+        with:
+          path: C:/hdf5
+          key: hdf5-1.10.10-windows-x64
+
+      - name: Download HDF5
+        if: steps.cache-hdf5.outputs.cache-hit != 'true'
+        shell: pwsh
+        run: |
+          $url = "https://github.com/HDFGroup/hdf5/releases/download/hdf5_1.10.10/hdf5-1.10.10-win-vs2022_intel.zip"
+          Invoke-WebRequest -Uri $url -OutFile hdf5.zip
+          Expand-Archive hdf5.zip -DestinationPath C:/hdf5
+
+      - name: Configure
+        shell: pwsh
+        run: |
+          cmake -B build `
+            -DCMAKE_BUILD_TYPE=Release `
+            -DHDF5_ROOT="C:/hdf5" `
+            -DH5CPP_BUILD_EXAMPLES=OFF `
+            -DH5CPP_BUILD_TESTS=OFF `
+            -DH5CPP_BUILD_BENCH=OFF
+
+      - name: Build (amalgamation only)
+        run: cmake --build build --target h5cpp-amalgamate --config Release
+
+      - name: Package
+        run: cd build && cpack -G NSIS
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: packages-windows-x64
+          path: build/*.exe
+          if-no-files-found: error
+
+  # ── AppImage (TODO) ───────────────────────────────────────────────────────────
+  # h5cpp is header-only; AppImage wraps executables, not headers.
+  # AppImage packaging of the h5cpp-compiler binary belongs in the
+  # h5cpp-compiler repo. Add it here when that binary is vendored.
+
+  # ── Publish release ──────────────────────────────────────────────────────────
+  publish:
+    name: Publish release
+    needs: [package-linux, package-macos, package-windows]
+    runs-on: ubuntu-22.04
+    if: startsWith(github.ref, 'refs/tags/')
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: packages-*
+          merge-multiple: true
+          path: dist/
+
+      - name: List artifacts
+        run: ls -lh dist/
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ github.ref_name }}" dist/* \
+            --title "h5cpp ${{ github.ref_name }}" \
+            --generate-notes \
+            --repo ${{ github.repository }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -339,3 +339,46 @@ install(FILES
     ${CMAKE_BINARY_DIR}/h5cpp-config-version.cmake
     DESTINATION ${INSTALL_DIR_CMAKE}
 )
+
+# ─── pkg-config ───────────────────────────────────────────────────────────────
+configure_file(cmake/h5cpp.pc.in h5cpp.pc @ONLY)
+install(FILES ${CMAKE_BINARY_DIR}/h5cpp.pc
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+
+# ─── CPack ────────────────────────────────────────────────────────────────────
+set(CPACK_PACKAGE_NAME                "h5cpp-dev")
+set(CPACK_PACKAGE_VENDOR              "Varga Labs")
+set(CPACK_PACKAGE_CONTACT             "steven.varga@gmail.com")
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "C++ template library for HDF5 I/O")
+set(CPACK_PACKAGE_HOMEPAGE_URL        "https://h5cpp.org")
+set(CPACK_PACKAGE_VERSION             "${H5CPP_VERSION}")
+set(CPACK_PACKAGE_VERSION_MAJOR       "${PROJECT_VERSION_MAJOR}")
+set(CPACK_PACKAGE_VERSION_MINOR       "${PROJECT_VERSION_MINOR}")
+set(CPACK_PACKAGE_VERSION_PATCH       "${PROJECT_VERSION_PATCH}")
+set(CPACK_RESOURCE_FILE_LICENSE       "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE")
+set(CPACK_STRIP_FILES                 OFF)
+
+# DEB — headers land at /usr/include/h5cpp/ (ambient, no -I flag needed)
+set(CPACK_PACKAGING_INSTALL_PREFIX    "/usr")
+set(CPACK_DEBIAN_PACKAGE_NAME         "h5cpp-dev")
+set(CPACK_DEBIAN_PACKAGE_SECTION      "libdevel")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS      "libhdf5-dev")
+set(CPACK_DEBIAN_PACKAGE_RECOMMENDS   "h5cpp-compiler")
+
+# RPM
+set(CPACK_RPM_PACKAGE_NAME            "h5cpp-devel")
+set(CPACK_RPM_PACKAGE_LICENSE         "MIT")
+set(CPACK_RPM_PACKAGE_GROUP           "Development/Libraries")
+set(CPACK_RPM_PACKAGE_REQUIRES        "hdf5-devel")
+set(CPACK_RPM_PACKAGE_SUGGESTS        "h5cpp-compiler")
+
+# NSIS (Windows installer)
+set(CPACK_NSIS_PACKAGE_NAME           "h5cpp ${H5CPP_VERSION}")
+set(CPACK_NSIS_DISPLAY_NAME           "H5CPP ${H5CPP_VERSION}")
+set(CPACK_NSIS_URL_INFO_ABOUT         "https://h5cpp.org")
+set(CPACK_NSIS_ENABLE_UNINSTALL_BEFORE_INSTALL ON)
+
+# productbuild (macOS .pkg)
+set(CPACK_PRODUCTBUILD_IDENTIFIER     "org.h5cpp.h5cpp")
+
+include(CPack)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20123216.svg)](https://doi.org/10.5281/zenodo.20123216)
 [![GitHub release](https://img.shields.io/github/v/release/vargalabs/h5cpp.svg)](https://github.com/vargalabs/h5cpp/releases)
 [![Documentation](https://img.shields.io/badge/docs-stable-blue)](https://vargalabs.github.io/h5cpp)
+[![Downloads](https://img.shields.io/github/downloads/vargalabs/h5cpp/total)](https://github.com/vargalabs/h5cpp/releases)
 
 Easy to use  [HDF5][hdf5] C++ templates for Serial and Paralell HDF5  
 ----------------------------------------------------------------------

--- a/cmake/h5cpp.pc.in
+++ b/cmake/h5cpp.pc.in
@@ -1,0 +1,7 @@
+Name: h5cpp
+Description: C++ template library for HDF5 I/O
+URL: https://h5cpp.org
+Version: @PROJECT_VERSION@
+Requires: hdf5
+Cflags: -I${includedir} -std=c++17
+Libs: -lhdf5 -lz -ldl -lm

--- a/h5cpp.pc
+++ b/h5cpp.pc
@@ -1,9 +1,0 @@
-
-Name: h5cpp
-Description: C++17 template library for major linear algebra systems and the STL
-URL: h5cpp.ca
-Version: 1.10.4.5-1
-Requires: hdf5
-Cflags: -I/usr/include/h5cpp  -std=c++17
-Libs:  -lhdf5  -lz -ldl -lm
-


### PR DESCRIPTION
## Summary

- **`cmake/h5cpp.pc.in`** — generated pkg-config template (`@PROJECT_VERSION@`, `${includedir}`); replaces the stale hardcoded `h5cpp.pc`
- **`CMakeLists.txt` CPack block** — metadata for all four generators:
  - DEB: `h5cpp-dev`, depends `libhdf5-dev`, recommends `h5cpp-compiler`, `CPACK_PACKAGING_INSTALL_PREFIX=/usr` → headers at `/usr/include/h5cpp/`
  - RPM: `h5cpp-devel`, requires `hdf5-devel`, suggests `h5cpp-compiler`
  - NSIS: `h5cpp` Windows installer
  - productbuild: `org.h5cpp.h5cpp` macOS `.pkg`
- **`.github/workflows/package.yml`** — tag-triggered (`v*`) + `workflow_dispatch`:
  - `ubuntu-22.04` amd64 → DEB + RPM
  - `ubuntu-22.04-arm` arm64 → DEB + RPM  
  - `macos-15` arm64 → productbuild `.pkg`
  - `windows-latest` x64 → NSIS `.exe`
  - `publish` job: downloads all artifacts, creates GitHub release with `gh release create`
- **`README.md`** — Downloads badge added
- **`h5cpp.pc`** — removed (was hardcoded v1.10.4.5-1; generated version takes over)

## Notes

- AppImage left as TODO comment in workflow — header-only library has no binary to wrap; belongs in h5cpp-compiler repo
- `install(DIRECTORY h5cpp ...)` already correct (no trailing slash) — `#include <h5cpp/all>` preserved after install
- HDF5 Windows: downloads `hdf5-1.10.10-win-vs2022_intel.zip` from HDFGroup releases; cached between runs

## Test plan

- [ ] `cmake -B build && cmake --build build --target h5cpp-amalgamate && cd build && cpack -G DEB` produces `h5cpp-dev-*.deb` with headers at `./usr/include/h5cpp/`
- [ ] `dpkg -c *.deb | grep h5cpp/all` — confirms include path
- [ ] CI matrix green on staging
- [ ] `workflow_dispatch` on `package.yml` produces artifacts for all four platforms