### PR TITLE
[#149]:svarga:feature, add std::valarray I/O support

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -284,6 +284,11 @@ add_executable(examples-raw EXCLUDE_FROM_ALL "raw_memory/raw.cpp")
 target_link_libraries(examples-raw ${LIBS} )
 add_dependencies(examples examples-raw)
 
+## valarray ###
+add_executable(examples-valarray EXCLUDE_FROM_ALL "linalg/valarray.cpp")
+target_link_libraries(examples-valarray ${LIBS} )
+add_dependencies(examples examples-valarray)
+
 ## stl ###
 add_executable(examples-stl EXCLUDE_FROM_ALL "stl/vector.cpp")
 target_link_libraries(examples-stl ${LIBS} )

--- a/examples/linalg/valarray.cpp
+++ b/examples/linalg/valarray.cpp
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2018-2020 Steven Varga, Toronto,ON Canada
+ * Author: Varga, Steven <steven@vargaconsulting.ca>
+ */
+#include <iostream>
+#include <valarray>
+#include <h5cpp/all>
+
+int main(){
+	h5::fd_t fd = h5::create("valarray.h5",H5F_ACC_TRUNC);
+	{ // CREATE - WRITE
+		std::valarray<double> v(10);
+		for (size_t i = 0; i < v.size(); ++i)
+			v[i] = static_cast<double>(i);
+		h5::write(fd, "std::valarray", v);
+	}
+	{ // READ
+		std::valarray<double> v = h5::read<std::valarray<double>>(fd, "std::valarray");
+		for (size_t i = 0; i < v.size(); ++i)
+			std::cout << v[i] << " ";
+		std::cout << std::endl;
+	}
+}

--- a/h5cpp/H5Mvalarray.hpp
+++ b/h5cpp/H5Mvalarray.hpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2018-2020 Steven Varga, Toronto,ON Canada
+ * Author: Varga, Steven <steven@vargaconsulting.ca>
+ */
+#pragma once
+
+#include <valarray>
+
+namespace h5::valarray {
+		template<class T> using array = ::std::valarray<T>;
+		template <class Object, class T = typename impl::decay<Object>::type>
+			using is_supported = std::bool_constant<std::is_same_v<Object,h5::valarray::array<T>>>;
+}
+
+namespace h5::meta {
+    template <class T> struct is_contiguous<h5::valarray::array<T>> : std::true_type {};
+}
+
+namespace h5::impl {
+	// 1.) object -> H5T_xxx
+	template <class T> struct decay<h5::valarray::array<T>>{ using type = T; };
+	// get read access to datastaore
+	template <class Object, class T = typename impl::decay<Object>::type> inline
+	std::enable_if_t< h5::valarray::is_supported<Object>::value,
+	const T*> data(const Object& ref ){
+			return std::begin(ref);
+	}
+	// read write access
+	template <class Object, class T = typename impl::decay<Object>::type> inline
+	std::enable_if_t< h5::valarray::is_supported<Object>::value,
+	T*> data( Object& ref ){
+			return std::begin(ref);
+	}
+	template<class T> struct rank<h5::valarray::array<T>> : public std::integral_constant<size_t,1>{};
+	template <class T> inline std::array<size_t,1> size( const h5::valarray::array<T>& ref ){ return { (hsize_t)ref.size() };}
+	template <class T> struct get<h5::valarray::array<T>> {
+		static inline h5::valarray::array<T> ctor( std::array<size_t,1> dims ){
+			return h5::valarray::array<T>( dims[0] );
+	}};
+}

--- a/h5cpp/core
+++ b/h5cpp/core
@@ -47,6 +47,7 @@
 	#include "H5Mitpp.hpp"
 	#include "H5Mblitz.hpp"
 	#include "H5Mublas.hpp"
+	#include "H5Mvalarray.hpp"
 	#include "H5Mxtensor.hpp"
 	#include "H5Mxtensorblas.hpp"
 	

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -90,6 +90,7 @@ add_test_case(H5Tcomplex)
 # produces an empty TU and the test still builds and passes silently.
 add_test_case(H5Tfloat16)
 set_target_properties(test-h5tfloat16 PROPERTIES CXX_STANDARD 23 CXX_STANDARD_REQUIRED OFF)
+add_test_case(H5Mvalarray)
 add_test_case(H5Zdeflate)
 add_test_case(H5Zshuffle)
 add_test_case(H5Zfletcher32)

--- a/test/H5Mvalarray.cpp
+++ b/test/H5Mvalarray.cpp
@@ -1,0 +1,80 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <doctest/all>
+#include <h5cpp/all>
+#include <valarray>
+#include <filesystem>
+#include <cmath>
+
+namespace {
+    struct temp_file {
+        std::string path;
+        explicit temp_file(const std::string& name)
+            : path((std::filesystem::temp_directory_path() / name).string()) {}
+        ~temp_file() {
+            std::error_code ec;
+            std::filesystem::remove(path, ec);
+        }
+    };
+}
+
+TEST_CASE("[#149] std::valarray<double> write/read round-trip") {
+    temp_file tf("h5mvalarray_double.h5");
+    auto fd = h5::create(tf.path, H5F_ACC_TRUNC);
+
+    std::valarray<double> written(10);
+    for (std::size_t i = 0; i < written.size(); ++i)
+        written[i] = static_cast<double>(i) * 0.5;
+
+    h5::write(fd, "valarray_double", written);
+    auto read = h5::read<std::valarray<double>>(fd, "valarray_double");
+
+    REQUIRE(read.size() == written.size());
+    for (std::size_t i = 0; i < written.size(); ++i)
+        CHECK(read[i] == doctest::Approx(written[i]));
+}
+
+TEST_CASE("[#149] std::valarray<float> write/read round-trip") {
+    temp_file tf("h5mvalarray_float.h5");
+    auto fd = h5::create(tf.path, H5F_ACC_TRUNC);
+
+    std::valarray<float> written(8);
+    for (std::size_t i = 0; i < written.size(); ++i)
+        written[i] = static_cast<float>(i) * 1.5f;
+
+    h5::write(fd, "valarray_float", written);
+    auto read = h5::read<std::valarray<float>>(fd, "valarray_float");
+
+    REQUIRE(read.size() == written.size());
+    for (std::size_t i = 0; i < written.size(); ++i)
+        CHECK(read[i] == doctest::Approx(written[i]));
+}
+
+TEST_CASE("[#149] std::valarray<int> write/read round-trip") {
+    temp_file tf("h5mvalarray_int.h5");
+    auto fd = h5::create(tf.path, H5F_ACC_TRUNC);
+
+    std::valarray<int> written = {1, 2, 3, 4, 5, 6, 7, 8};
+    h5::write(fd, "valarray_int", written);
+    auto read = h5::read<std::valarray<int>>(fd, "valarray_int");
+
+    REQUIRE(read.size() == written.size());
+    for (std::size_t i = 0; i < written.size(); ++i)
+        CHECK(read[i] == written[i]);
+}
+
+TEST_CASE("[#149] std::valarray<double> extent matches size()") {
+    temp_file tf("h5mvalarray_extent.h5");
+    auto fd = h5::create(tf.path, H5F_ACC_TRUNC);
+
+    constexpr std::size_t N = 16;
+    std::valarray<double> written(N);
+    for (std::size_t i = 0; i < N; ++i) written[i] = static_cast<double>(i);
+
+    h5::write(fd, "va", written);
+
+    auto ds = h5::open(fd, "va", H5F_ACC_RDONLY);
+    auto sp = h5::get_space(ds);
+    hsize_t dims[1];
+    H5Sget_simple_extent_dims(static_cast<hid_t>(sp), dims, nullptr);
+    CHECK(dims[0] == N);
+}


### PR DESCRIPTION
Closes #149

## Summary
- Add `h5cpp/H5Mvalarray.hpp` with full `std::valarray<T>` support: `decay`, `data()`, `rank`, `size()`, `get<>`, and `is_contiguous` specializations
- Include `H5Mvalarray.hpp` from `h5cpp/core`
- Add `examples/linalg/valarray.cpp` write/read example wired into `examples/CMakeLists.txt`
- Add `test/H5Mvalarray.cpp` with four TEST_CASEs: `double`, `float`, and `int` round-trips plus extent verification via `H5Sget_simple_extent_dims`

## Test plan
- [ ] `test-h5mvalarray` builds and passes on all CI platforms
- [ ] `double`, `float`, and `int` write/read round-trips pass
- [ ] Extent check confirms dataset dims match `valarray::size()`