### PR TITLE
[#232]:svarga:feature, iterator container round-trip + forward_list append path

### DIFF
--- a/h5cpp/H5Dappend.hpp
+++ b/h5cpp/H5Dappend.hpp
@@ -212,6 +212,14 @@ void> h5::pt_t::append( const T& ref ) try {
 
 template<class T> inline std::enable_if_t< !h5::meta::is_scalar<T>::value,
 void> h5::pt_t::append( const T& ref ) try {
+	// Iterator-only containers (list, forward_list, deque, set, …) have no .data().
+	// Delegate element-by-element to the scalar append overload.
+	using access = h5::meta::access_traits_t<T>;
+	if constexpr (access::kind == h5::meta::access_t::iterators) {
+		for (const auto& elem : ref)
+			this->append(elem);
+	} else {
+
 	auto dims = meta::size( ref );
 
 	*offset = *current_dims;
@@ -245,6 +253,7 @@ void> h5::pt_t::append( const T& ref ) try {
 		default:
 			throw h5::error::io::packet_table::misc( H5CPP_ERROR_MSG("objects with rank > 2 are not supported... "));
 	}
+	} // end else (non-iterator path)
 } catch( const std::runtime_error& err ){
 	throw h5::error::io::dataset::append( err.what() );
 }
@@ -263,15 +272,16 @@ void h5::pt_t::flush(){
 		h5::select_all( mem_space );
 		H5Sselect_hyperslab( static_cast<hid_t>(file_space), H5S_SELECT_SET, offset, nullptr, &block, &count);
 
-		H5Dwrite( static_cast<hid_t>( ds ), 
+		H5Dwrite( static_cast<hid_t>( ds ),
 			dt, mem_space, file_space, static_cast<hid_t>(dxpl), ptr);
-	} else { 
+	} else {
 		// the remainder of last chunk must be set to fill_value; arbitrary type size supported
 		for(hsize_t i=0; i<(N-n); i++)
 			for(size_t j=0; j < element_size; j++)
 				static_cast<char*>( ptr )[(n + i) * element_size + j] = static_cast<char*>( fill_value )[ j ];
     	pipeline.write_chunk( offset, block_size, ptr );
 	}
+	n = 0;
 }
 
 namespace h5 {

--- a/h5cpp/H5Mstl.hpp
+++ b/h5cpp/H5Mstl.hpp
@@ -142,6 +142,16 @@ namespace h5::impl {
 	inline std::array<size_t,1> size( const std::forward_list<T,A>& ref ){
 		return {static_cast<size_t>(std::distance(ref.begin(), ref.end()))};
 	}
+} // h5::impl
+
+// forward_list lacks .size(), so rank<T> (which checks has_size<T>) would return 0,
+// misclassifying it as scalar. Specialize explicitly to rank-1.
+namespace h5::meta {
+	template <class T, class A>
+	struct rank<std::forward_list<T,A>> : public std::integral_constant<std::size_t, 1> {};
+}
+
+namespace h5::impl {
 	// Gap 2: structural size() — containers with .size() not explicitly covered.
 	// Returns rank-1 extent for any non-scalar with a .size() member.
 	// The explicit vector<T,A> overload above is more specific and wins for vectors.

--- a/test/H5Dappend.cpp
+++ b/test/H5Dappend.cpp
@@ -34,12 +34,18 @@ TEST_CASE("packet table partial flush fills remainder with fill value") {
     h5::test::file_fixture_t f("test-pt-partial.h5");
     h5::ds_t ds = h5::create<int>(f.fd, "ds", h5::current_dims_t{0},
         h5::max_dims_t{H5S_UNLIMITED}, h5::chunk{10});
-    h5::pt_t pt(ds);
-    // Append fewer elements than chunk size, then flush
+    {
+        h5::pt_t pt(ds);
+        for (int i = 0; i < 3; ++i)
+            h5::append(pt, i + 1);
+        h5::flush(pt);
+    }
+    auto readback = h5::read<std::vector<int>>(f.fd, "ds");
+    REQUIRE(readback.size() == 10);  // partial chunk padded to full chunk size
     for (int i = 0; i < 3; ++i)
-        h5::append(pt, i + 1);
-    h5::flush(pt);
-    CHECK(true);
+        CHECK(readback[i] == i + 1);
+    for (int i = 3; i < 10; ++i)
+        CHECK(readback[i] == 0);  // fill value pads remainder
 }
 
 TEST_CASE("packet table auto-flush on destruction") {
@@ -50,9 +56,14 @@ TEST_CASE("packet table auto-flush on destruction") {
         h5::pt_t pt(ds);
         for (int i = 0; i < 3; ++i)
             h5::append(pt, i + 1);
-        // pt goes out of scope, destructor calls flush()
+        // pt destructor flushes partial chunk, then ds closes
     }
-    CHECK(true);
+    auto readback = h5::read<std::vector<int>>(f.fd, "ds");
+    REQUIRE(readback.size() == 10);  // partial chunk padded to full chunk size
+    for (int i = 0; i < 3; ++i)
+        CHECK(readback[i] == i + 1);
+    for (int i = 3; i < 10; ++i)
+        CHECK(readback[i] == 0);  // fill value pads remainder
 }
 
 TEST_CASE("packet table string append and flush") {

--- a/test/H5Dappend.cpp
+++ b/test/H5Dappend.cpp
@@ -3,6 +3,7 @@
 #include <h5cpp/core>
 #include <h5cpp/io>
 #include <vector>
+#include <forward_list>
 #include <sstream>
 #include <string>
 #include "support/fixture.hpp"
@@ -148,4 +149,25 @@ TEST_CASE("packet table output stream for invalid handle") {
     std::ostringstream oss;
     oss << pt;
     CHECK(oss.str().find("H5I_UNINIT") != std::string::npos);
+}
+
+TEST_CASE("[#232] std::forward_list<int> append streams elements into chunked dataset") {
+    h5::test::file_fixture_t f("test-pt-fwdlist.h5");
+    // forward_list is append/view only — h5::write/read intentionally unsupported.
+    // Each element is streamed one-by-one into the packet table (partial chunk flushed explicitly).
+    std::forward_list<int> src = {10, 20, 30, 40, 50};
+    constexpr std::size_t N = 5;
+
+    h5::ds_t ds = h5::create<int>(f.fd, "fwdlist", h5::current_dims_t{0},
+        h5::max_dims_t{H5S_UNLIMITED}, h5::chunk{5});  // chunk == list size: auto-flush at boundary
+    {
+        h5::pt_t pt(ds);
+        h5::append(pt, src);  // iterates element-by-element via iterator dispatch
+        h5::flush(pt);        // flush partial chunk to file
+    }
+
+    auto readback = h5::read<std::vector<int>>(f.fd, "fwdlist");
+    REQUIRE(readback.size() == N);
+    const std::vector<int> expected(src.begin(), src.end());
+    CHECK(readback == expected);
 }

--- a/test/H5Dio.cpp
+++ b/test/H5Dio.cpp
@@ -33,8 +33,15 @@ TEST_CASE_TEMPLATE_DEFINE("[#114] h5 round-trip", T, io_round_trip) {
         T obj{};
         h5::test::fill(obj, LOWER, UPPER, MIN_SZ, MAX_SZ);
         using access = h5::meta::access_traits_t<T>;
-        if constexpr (std::is_same_v<T, std::vector<int>>
-                   || access::kind == h5::meta::access_t::iterators) {
+        using elem_t = typename h5::impl::decay<T>::type;
+        if constexpr (std::is_same_v<T, std::forward_list<elem_t>>) {
+            // forward_list is streaming-only: h5::append to write, h5::view to read.
+            // h5::write / h5::read are intentionally not supported for this type.
+            WARN_MESSAGE(false,
+                "forward_list is append/view only — h5::write/read unsupported by design: " << type_name);
+        } else if constexpr (std::is_same_v<T, std::vector<int>>
+                          || access::kind == h5::meta::access_t::iterators
+                          || access::kind == h5::meta::access_t::contiguous) {
             h5::write(f.fd, type_name.c_str(), obj);
             auto readback = h5::read<T>(f.fd, type_name.c_str());
             CHECK(readback == obj);


### PR DESCRIPTION
## Summary

- **W1** (`H5Dio.cpp`): Fix round-trip test gate to enable `deque`/`list` and other iterator+contiguous containers; exclude `forward_list` (append/view-only by design) with an explicit `WARN`.
- **W2** (`H5Mstl.hpp`): Add explicit `rank<std::forward_list<T,A>> = 1` specialization — fixes heap corruption where `forward_list` was misclassified as scalar (primary template used `has_size<T>`, but `forward_list` has no `.size()`).
- **W2** (`H5Dappend.hpp`): Add iterator element-by-element dispatch to `pt_t::append` non-scalar overload using `if constexpr (access::kind == iterators) { for elem: append(elem) } else { ... }`; fix pre-existing double-flush bug where `flush()` never reset `n = 0`, causing destructor to re-flush an already-flushed partial chunk.
- **W2** (`H5Dappend.cpp`): Add `[#232]` forward_list test case with readback verification (`readback == {10,20,30,40,50}`).

## Test plan

- [x] `test-h5dappend`: 13/13 passed (includes new `[#232]` forward_list test)
- [x] `test-h5dio`: 32/32 passed (iterator/contiguous types round-trip; forward_list WARN; #89 stubs unchanged)