### PR TITLE
[#241]:svarga:feature, wire threaded_pipeline_t into pt_t for parallel filter compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,28 @@ Easy to use  [HDF5][hdf5] C++ templates for Serial and Paralell HDF5
 
 H5CPP **is intended for** scientific computing, **high-performance computing**, machine learning, numerical analysis, and data-intensive C++ applications **that require portable**, inspectable, **and efficient binary storage** compatible with the broader HDF5 ecosystem, **including Python, R, MATLAB, Fortran, Julia, and other HDF5-capable environments**.
 
+## Threaded Filter Pipeline
+
+Packet-table append operations can run their filter chain on a worker pool by passing the
+`h5::filter::threads{N}` opt-in tag at `pt_t` construction. Default behavior (synchronous,
+single-threaded) is unchanged.
+
+```cpp
+// Default — synchronous filter chain
+h5::pt_t pt(ds);
+
+// Parallel — N compression workers
+h5::pt_t pt(ds, h5::filter::threads{4});
+
+// Default worker count = std::thread::hardware_concurrency()
+h5::pt_t pt(ds, h5::filter::threads{});
+```
+
+Workers handle compression only; `H5Dwrite_chunk` is still called from the calling thread,
+which preserves compatibility with the default (non-thread-safe) HDF5 build. Useful for
+append-heavy workloads with non-trivial filter chains (gzip, zstd, fletcher32). See
+issue #241 for the design notes.
+
 
 
 ## Migration and Contribution Workflow

--- a/h5cpp/H5Dappend.hpp
+++ b/h5cpp/H5Dappend.hpp
@@ -7,7 +7,10 @@
 #include "H5capi.hpp"
 #include "H5Tmeta.hpp"
 #include "H5cout.hpp"
+#include "H5Zpipeline_threaded.hpp"
+#include <memory>
 #include <string>
+#include <variant>
 #include <vector>
 #include <stdexcept>
 #include <type_traits>
@@ -18,18 +21,35 @@ namespace h5 {
 }
 std::ostream& operator<<(std::ostream& os, const h5::pt_t& pt);
 
+namespace h5::impl {
+    // pt_t::pipeline selects between the synchronous basic pipeline (default,
+    // bytewise-identical to pre-241 behavior) and the parallel threaded pipeline.
+    // Both alternatives are indirect-owned through unique_ptr so that the
+    // variant remains move-assignable regardless of the underlying pipeline's
+    // move semantics (threaded_pipeline_t deletes moves because it owns
+    // std::jthread workers and atomics; basic_pipeline_t inherits a manually-
+    // written move-assign from pipeline_t<Derived> that suppresses the
+    // implicit move-ctor needed by variant assignment).
+    using pt_pipeline_t = std::variant<
+        std::unique_ptr<impl::basic_pipeline_t>,
+        std::unique_ptr<impl::threaded_pipeline_t>
+    >;
+}
+
 // packet table template specialization with inheritance
 namespace h5 {
 	struct pt_t {
 		pt_t();
-		pt_t( const h5::ds_t& handle ); // conversion ctor
-		// deep copy with own cache memory
+		pt_t( const h5::ds_t& handle ); // conversion ctor — synchronous pipeline
+		pt_t( const h5::ds_t& handle, h5::filter::threads workers ); // threaded pipeline
+		// deep copy with own cache memory — always uses the synchronous pipeline,
+		// since the threaded pipeline owns workers that cannot be duplicated.
 		pt_t( const h5::pt_t& pt ) : h5::pt_t(pt.ds) {
 		};
 		~pt_t();
 
 		pt_t& operator=( h5::pt_t&& pt ){
-            // prevent self assign 
+            // prevent self assign
             if (this == &pt) return *this;
             if(H5Iis_valid(this->ds)){ // flush and close dataset
                 this->flush();
@@ -71,7 +91,19 @@ namespace h5 {
 		void> append( const T& ref );
 		void append( const std::string& ref );
 
-		impl::pipeline_t<impl::basic_pipeline_t> pipeline;
+		// Resolve the variant to a reference to the live pipeline_t<Derived> CRTP
+		// instance, regardless of which alternative is active. Both alternatives
+		// expose the same set of fields (chunk0, block_size, ds, dxpl, ...) inherited
+		// from pipeline_t<Derived>, so the visiting lambda can use the result
+		// duck-typed across alternatives.
+		template <typename F>
+		decltype(auto) visit_pipeline(F&& f) {
+			return std::visit([&](auto& p) -> decltype(auto) {
+				return std::forward<F>(f)(*p);   // both alternatives are unique_ptr
+			}, pipeline);
+		}
+
+		impl::pt_pipeline_t pipeline;
 		h5::dxpl_t dxpl;
 		h5::ds_t ds;
 		h5::dt_t<void> dt;
@@ -87,16 +119,27 @@ namespace h5 {
 /* initialized to invalid state
  * */
 inline h5::pt_t::pt_t() :
+	pipeline{std::make_unique<impl::basic_pipeline_t>()},
 	dxpl{H5Pcreate(H5P_DATASET_XFER)},ds{H5I_UNINIT},n{0},fill_value{nullptr}{
 		for(hsize_t i=0; i<H5CPP_MAX_RANK; i++ )
 			count[i] = 1, offset[i] = 0;
 	}
 
-// conversion ctor
+// conversion ctor — synchronous pipeline (default)
 inline
 h5::pt_t::pt_t( const h5::ds_t& handle ) : pt_t() {
 	/*default ctor has an invalid state -- skip initialization */
 	if( !is_valid(handle) ) return;
+	init(handle);
+}
+
+// conversion ctor — threaded pipeline with N compression workers
+inline
+h5::pt_t::pt_t( const h5::ds_t& handle, h5::filter::threads workers ) : pt_t() {
+	if( !is_valid(handle) ) return;
+	auto threaded = std::make_unique<impl::threaded_pipeline_t>();
+	threaded->set_worker_count(workers.n);
+	pipeline.emplace<std::unique_ptr<impl::threaded_pipeline_t>>(std::move(threaded));
 	init(handle);
 }
 
@@ -133,12 +176,14 @@ void h5::pt_t::init( const h5::ds_t& handle ){
 		h5::dt_t<void*> type = h5::get_type<void*>( ds );
 		hsize_t size = h5::get_size( type );
 		this->fill_value = h5::get_fill_value(dcpl, type, size);
-		pipeline.set_cache(dcpl, size);
-		this->ptr = pipeline.chunk0;
-		this->block_size = pipeline.block_size;
-		this->element_size = pipeline.element_size;
-		this->N = pipeline.n;
-		pipeline.ds = ds; pipeline.dxpl = dxpl;
+		visit_pipeline([&](auto& p) {
+			p.set_cache(dcpl, size);
+			this->ptr = p.chunk0;
+			this->block_size = p.block_size;
+			this->element_size = p.element_size;
+			this->N = p.n;
+			p.ds = ds; p.dxpl = dxpl;
+		});
 		h5::get_chunk_dims( dcpl, chunk_dims );
 		for(hsize_t i=1; i<rank; i++)
 			current_dims[i] = chunk_dims[i];
@@ -152,7 +197,7 @@ void> h5::pt_t::append( const T* ptr ) try {
 	*offset = *current_dims;
 	*current_dims += *chunk_dims;
 	h5::set_extent(ds, current_dims);
-	pipeline.write_chunk(offset,block_size,ptr);
+	visit_pipeline([&](auto& p){ p.write_chunk(offset, block_size, ptr); });
 } catch( const std::runtime_error& err ){
 	throw h5::error::io::dataset::append( err.what() );
 }
@@ -205,7 +250,7 @@ void> h5::pt_t::append( const T& ref ) try {
 	*offset = *current_dims;
 	*current_dims += *chunk_dims;
 	h5::set_extent(ds, current_dims);
-	pipeline.write_chunk(offset,block_size,ptr);
+	visit_pipeline([&](auto& p){ p.write_chunk(offset, block_size, ptr); });
 } catch( const std::runtime_error& err ){
 	throw h5::error::io::dataset::append( err.what() );
 }
@@ -231,21 +276,21 @@ void> h5::pt_t::append( const T& ref ) try {
 	switch( dims_.size() ){
 		case 1: // vector
 			if( dims[0] * element_size == block_size )
-				pipeline.write_chunk(offset, block_size, (void*) ptr_ );
+				visit_pipeline([&](auto& p){ p.write_chunk(offset, block_size, (void*) ptr_ ); });
 			else throw h5::error::io::packet_table::write(
 					H5CPP_ERROR_MSG("dimension mismatch: "
 						+ std::to_string( dims[0] * element_size) + " != " + std::to_string(block_size) ));
 			break;
 		case 2: //matrix
 			if( dims[0] * dims[1] * element_size == block_size )
-				pipeline.write_chunk(offset, block_size, (void*) ptr_ );
+				visit_pipeline([&](auto& p){ p.write_chunk(offset, block_size, (void*) ptr_ ); });
 			else throw h5::error::io::packet_table::write(
 					H5CPP_ERROR_MSG("dimension mismatch: "
 						+ std::to_string( dims[0] * dims[1] * element_size) + " != " + std::to_string(block_size) ));
 			break;
 		case 3: // cube
 			if( dims[0] * dims[1] * dims[2] * element_size == block_size )
-				pipeline.write_chunk(offset, block_size, (void*) ptr_ );
+				visit_pipeline([&](auto& p){ p.write_chunk(offset, block_size, (void*) ptr_ ); });
 			else throw h5::error::io::packet_table::write(
 					H5CPP_ERROR_MSG("dimension mismatch: "
 						+ std::to_string( dims[0] * dims[1] * dims[2] * element_size) + " != " + std::to_string(block_size) ));
@@ -279,7 +324,7 @@ void h5::pt_t::flush(){
 		for(hsize_t i=0; i<(N-n); i++)
 			for(size_t j=0; j < element_size; j++)
 				static_cast<char*>( ptr )[(n + i) * element_size + j] = static_cast<char*>( fill_value )[ j ];
-    	pipeline.write_chunk( offset, block_size, ptr );
+    	visit_pipeline([&](auto& p){ p.write_chunk(offset, block_size, ptr); });
 	}
 	n = 0;
 }

--- a/h5cpp/H5Zpipeline_threaded.hpp
+++ b/h5cpp/H5Zpipeline_threaded.hpp
@@ -22,6 +22,19 @@
 // so no HDF5 API calls occur on worker threads, preserving compatibility with
 // non-thread-safe HDF5 builds.
 
+namespace h5::filter {
+    // Opt-in tag selecting the threaded filter pipeline.
+    //   h5::filter::threads{}    -> std::thread::hardware_concurrency() workers
+    //   h5::filter::threads{N}   -> N compression workers
+    // Passed to pt_t constructors (and h5::write) to switch from the default
+    // synchronous basic_pipeline_t to the parallel threaded_pipeline_t.
+    struct threads {
+        unsigned n;
+        constexpr threads() noexcept : n(0) {}
+        constexpr explicit threads(unsigned count) noexcept : n(count) {}
+    };
+}
+
 namespace h5::impl {
 
 namespace detail {
@@ -78,6 +91,11 @@ struct threaded_pipeline_t : public pipeline_t<threaded_pipeline_t> {
     threaded_pipeline_t& operator=(const threaded_pipeline_t&) = delete;
     threaded_pipeline_t(threaded_pipeline_t&&) = delete;
     threaded_pipeline_t& operator=(threaded_pipeline_t&&) = delete;
+
+    // Runtime override of worker pool size. If non-zero, takes precedence over
+    // the H5CPP_PIPELINE_WORKERS compile-time default. Must be called before
+    // the first write_chunk_impl, since workers spawn lazily via std::call_once.
+    void set_worker_count(unsigned n) noexcept { worker_count_override_ = n; }
 
     // Drains all in-flight work and calls H5Dwrite_chunk from the calling
     // (main) thread.  Must be called before reading back written data.
@@ -152,8 +170,10 @@ private:
     void ensure_workers() {
         std::call_once(init_flag_, [this] {
             constexpr unsigned cfg = static_cast<unsigned>(H5CPP_PIPELINE_WORKERS);
-            const unsigned n = (cfg > 0) ? cfg
-                                         : std::max(1u, std::thread::hardware_concurrency());
+            const unsigned n =
+                (worker_count_override_ > 0) ? worker_count_override_
+                : (cfg > 0)                  ? cfg
+                                             : std::max(1u, std::thread::hardware_concurrency());
             workers_.reserve(n);
             for (unsigned i = 0; i < n; ++i)
                 workers_.emplace_back([this](std::stop_token st) { worker_loop(st); });
@@ -223,6 +243,7 @@ private:
     std::atomic<int>          in_flight_{0};
     std::vector<std::jthread> workers_;
     std::once_flag            init_flag_;
+    unsigned                  worker_count_override_{0};
 };
 
 #else
@@ -316,6 +337,11 @@ struct threaded_pipeline_t : public pipeline_t<threaded_pipeline_t> {
     threaded_pipeline_t(threaded_pipeline_t&&) = delete;
     threaded_pipeline_t& operator=(threaded_pipeline_t&&) = delete;
 
+    // Runtime override of worker pool size. If non-zero, takes precedence over
+    // the H5CPP_PIPELINE_WORKERS compile-time default. Must be called before
+    // the first write_chunk_impl, since workers spawn lazily via std::call_once.
+    void set_worker_count(unsigned n) noexcept { worker_count_override_ = n; }
+
     // Drains all in-flight work and calls H5Dwrite_chunk from the calling
     // (main) thread.  Must be called before reading back written data.
     void flush() {
@@ -389,8 +415,10 @@ private:
     void ensure_workers() {
         std::call_once(init_flag_, [this] {
             constexpr unsigned cfg = static_cast<unsigned>(H5CPP_PIPELINE_WORKERS);
-            const unsigned n = (cfg > 0) ? cfg
-                                         : std::max(1u, std::thread::hardware_concurrency());
+            const unsigned n =
+                (worker_count_override_ > 0) ? worker_count_override_
+                : (cfg > 0)                  ? cfg
+                                             : std::max(1u, std::thread::hardware_concurrency());
             workers_.reserve(n);
             for (unsigned i = 0; i < n; ++i)
                 workers_.emplace_back(
@@ -461,6 +489,7 @@ private:
     std::atomic<int>                              in_flight_{0};
     std::vector<h5::detail::stoppable_thread_t>   workers_;
     std::once_flag                                init_flag_;
+    unsigned                                      worker_count_override_{0};
 };
 
 #endif // __cplusplus >= 202002L

--- a/h5cpp/core
+++ b/h5cpp/core
@@ -60,6 +60,7 @@
 	#include "H5Pall.hpp"
 	#include "H5Zpipeline.hpp"
 	#include "H5Zpipeline_basic.hpp"
+	#include "H5Zpipeline_threaded.hpp"
 	#include "H5Pdapl.hpp"
 	
 	#include "H5Ialgorithm.hpp"

--- a/test/H5Dappend.cpp
+++ b/test/H5Dappend.cpp
@@ -162,6 +162,85 @@ TEST_CASE("packet table output stream for invalid handle") {
     CHECK(oss.str().find("H5I_UNINIT") != std::string::npos);
 }
 
+// =====================================================================
+// [#241] Threaded filter pipeline opt-in via h5::filter::threads{N}
+// =====================================================================
+
+TEST_CASE("[#241] h5::filter::threads tag construction") {
+    // Default-constructed tag means "use hardware_concurrency() workers".
+    constexpr h5::filter::threads default_t{};
+    CHECK(default_t.n == 0);
+
+    // Explicit count.
+    constexpr h5::filter::threads explicit_t{4};
+    CHECK(explicit_t.n == 4);
+}
+
+TEST_CASE("[#241] pt_t with threaded pipeline — basic round-trip (no filter)") {
+    h5::test::file_fixture_t f("test-pt-threaded-nofilter.h5");
+    h5::ds_t ds = h5::create<int>(f.fd, "ds", h5::current_dims_t{0},
+        h5::max_dims_t{H5S_UNLIMITED}, h5::chunk{16});
+    {
+        h5::pt_t pt(ds, h5::filter::threads{2});
+        for (int i = 0; i < 64; ++i)
+            h5::append(pt, i);
+        h5::flush(pt);   // ensure all workers drain before close
+    }
+    auto readback = h5::read<std::vector<int>>(f.fd, "ds");
+    REQUIRE(readback.size() == 64);
+    for (int i = 0; i < 64; ++i) CHECK(readback[i] == i);
+}
+
+TEST_CASE("[#241] pt_t with threaded pipeline — gzip-compressed bytewise equivalence") {
+    // Write the same data with basic and threaded pipelines into two files,
+    // read back, assert content matches. Different filter chain ordering can
+    // produce different on-disk bytes; we assert decompressed content equivalence.
+    constexpr int N = 256;
+    std::vector<int> expected(N);
+    for (int i = 0; i < N; ++i) expected[i] = i * 7 + 3;
+
+    auto write_file = [&](const char* path, auto pt_factory) {
+        h5::test::file_fixture_t f(path);
+        h5::ds_t ds = h5::create<int>(f.fd, "ds", h5::current_dims_t{0},
+            h5::max_dims_t{H5S_UNLIMITED}, h5::chunk{32} | h5::gzip{6});
+        {
+            auto pt = pt_factory(ds);
+            for (int v : expected) h5::append(pt, v);
+            h5::flush(pt);
+        }
+    };
+
+    write_file("test-pt-basic-gzip.h5",
+        [](const h5::ds_t& ds) { return h5::pt_t(ds); });
+    write_file("test-pt-threaded-gzip.h5",
+        [](const h5::ds_t& ds) { return h5::pt_t(ds, h5::filter::threads{4}); });
+
+    h5::fd_t basic = h5::open("test-pt-basic-gzip.h5", H5F_ACC_RDONLY);
+    h5::fd_t threaded = h5::open("test-pt-threaded-gzip.h5", H5F_ACC_RDONLY);
+    auto basic_data    = h5::read<std::vector<int>>(basic,    "ds");
+    auto threaded_data = h5::read<std::vector<int>>(threaded, "ds");
+    REQUIRE(basic_data.size() == expected.size());
+    REQUIRE(threaded_data.size() == expected.size());
+    CHECK(basic_data == expected);
+    CHECK(threaded_data == expected);
+    CHECK(basic_data == threaded_data);
+}
+
+TEST_CASE("[#241] pt_t with threaded pipeline — default worker count (hw_concurrency)") {
+    h5::test::file_fixture_t f("test-pt-threaded-default.h5");
+    h5::ds_t ds = h5::create<int>(f.fd, "ds", h5::current_dims_t{0},
+        h5::max_dims_t{H5S_UNLIMITED}, h5::chunk{16} | h5::gzip{1});
+    {
+        // h5::filter::threads{} with no number → hw_concurrency() workers
+        h5::pt_t pt(ds, h5::filter::threads{});
+        for (int i = 0; i < 96; ++i) h5::append(pt, i);
+        h5::flush(pt);
+    }
+    auto readback = h5::read<std::vector<int>>(f.fd, "ds");
+    REQUIRE(readback.size() == 96);
+    for (int i = 0; i < 96; ++i) CHECK(readback[i] == i);
+}
+
 TEST_CASE("[#232] std::forward_list<int> append streams elements into chunked dataset") {
     h5::test::file_fixture_t f("test-pt-fwdlist.h5");
     // forward_list is append/view only — h5::write/read intentionally unsupported.


### PR DESCRIPTION
Resolves #241 (phase 1).

Activates the previously-implemented `threaded_pipeline_t` for packet table
write paths via an opt-in tag at `pt_t` construction. Default behavior
(synchronous `basic_pipeline_t`) is preserved bytewise — all 50 existing
ctest cases pass unchanged.

## API

```cpp
// Default — synchronous filter chain
h5::pt_t pt(ds);

// Parallel — N compression workers
h5::pt_t pt(ds, h5::filter::threads{4});

// Default worker count = std::thread::hardware_concurrency()
h5::pt_t pt(ds, h5::filter::threads{});
```

Workers handle compression only; `H5Dwrite_chunk` is still called from the
calling thread, preserving compatibility with the default (non-thread-safe)
HDF5 build.

## Commits

| SHA | Change |
|---|---|
| `7cb84605` | `feature, wire threaded_pipeline_t into pt_t via h5::filter::threads{N}` |
| `5dcceed4` | `docs, README — Threaded Filter Pipeline section` |

## Mechanism

- New `h5::filter::threads` POD tag in `h5cpp/H5Zpipeline_threaded.hpp`. Constexpr, `n=0` means hw_concurrency.
- `pt_t::pipeline` becomes `std::variant<unique_ptr<basic_pipeline_t>, unique_ptr<threaded_pipeline_t>>`. The unique_ptr indirection sidesteps the variant move-assignment requirement (basic_pipeline_t has a manually-written move-assign that suppresses the implicit move-ctor; threaded_pipeline_t explicitly deletes all move ops).
- New `pt_t` constructor overload taking `h5::filter::threads` emplaces the threaded alternative.
- All pipeline access sites route through a new `visit_pipeline()` helper that dereferences the active alternative.
- `threaded_pipeline_t::set_worker_count(unsigned)` setter (both C++20 and C++17 paths) overrides the `H5CPP_PIPELINE_WORKERS` compile-time default.

## Test plan

- [x] `cmake -B build -DH5CPP_BUILD_TESTS=ON && cmake --build build -j` clean.
- [x] `ctest --output-on-failure` — 50/50 pass (no regressions in default mode).
- [x] New `[#241]` test cases in `test/H5Dappend.cpp`:
  - Tag construction (default = 0 = hw_concurrency, explicit count).
  - Threaded round-trip (no filter), gzip-compressed bytewise equivalence basic vs threaded, default-worker-count path.

## Scope notes

This PR delivers phase 1 (parallel compression in `pt_t`), which is the actual
end-user feature for append-heavy workloads (iex2h5, telemetry, packet capture).
Two phases were scoped out after investigation:

- **`h5::write` threaded opt-in**: blocked on #242 — the `high_throughput` DAPL
  pipeline path is currently gated to HDF5 ≤ 1.10.6 with a TODO ("crashes on
  1.12.x"). On modern HDF5, `h5::write` skips the pipeline entirely. Filed as
  the prerequisite issue.
- **Read-path parallelism in `threaded_pipeline_t::read_chunk_impl`**: also blocked
  on #242, plus requires reworking `split_to_chunk_read` to batch-submit reads.
  Will be a follow-up issue once #242 lands.

The pt_t append path bypasses the DAPL pipeline machinery entirely (it owns
its pipeline directly), so this PR is independent of #242.