### PR TITLE
[#242]:svarga:fix, add copy callback to high_throughput DAPL pipeline property

### DIFF
--- a/h5cpp/H5Dread.hpp
+++ b/h5cpp/H5Dread.hpp
@@ -62,7 +62,18 @@ namespace h5 {
 		using element_t = typename impl::decay<T>::type;
 		h5::meta::resolved_type_t<element_t> mem_type;
 		hid_t dapl = h5::get_access_plist( ds );
-		if( H5Pexist(dapl, H5CPP_DAPL_HIGH_THROUGHPUT) ){
+		// See H5Dwrite.hpp for the rationale: pipeline path uses H5Dread_chunk,
+		// which only works on chunked datasets. Guard on H5D_CHUNKED so DAPLs
+		// with the flag applied to contiguous datasets fall through to H5Dread.
+		const bool use_pipeline = [&]() {
+			if (!H5Pexist(dapl, H5CPP_DAPL_HIGH_THROUGHPUT)) return false;
+			hid_t dcpl_id = H5Dget_create_plist(static_cast<hid_t>(ds));
+			if (dcpl_id < 0) return false;
+			H5D_layout_t layout = H5Pget_layout(dcpl_id);
+			H5Pclose(dcpl_id);
+			return layout == H5D_CHUNKED;
+		}();
+		if( use_pipeline ){
 			h5::impl::pipeline_t<impl::basic_pipeline_t>* filters;
 			H5Pget(dapl, H5CPP_DAPL_HIGH_THROUGHPUT, &filters);
 			filters->read(ds, offset, stride, block, count, dxpl, ptr);

--- a/h5cpp/H5Dwrite.hpp
+++ b/h5cpp/H5Dwrite.hpp
@@ -87,7 +87,20 @@ namespace h5 {
 		hid_t dapl = h5::get_access_plist( ds );
 		herr_t err = 0;
 
-		if( H5Pexist(dapl, H5CPP_DAPL_HIGH_THROUGHPUT) ){
+		// The high_throughput pipeline uses H5Dwrite_chunk, which requires a
+		// chunked dataset layout. Guard on H5D_CHUNKED so a DAPL with the flag
+		// applied to a contiguous/compact dataset falls through to standard
+		// H5Dwrite rather than triggering "not a chunked dataset" errors
+		// (which manifest as a SegFault on Windows MSVC, see #242 follow-up).
+		const bool use_pipeline = [&]() {
+			if (!H5Pexist(dapl, H5CPP_DAPL_HIGH_THROUGHPUT)) return false;
+			hid_t dcpl_id = H5Dget_create_plist(static_cast<hid_t>(ds));
+			if (dcpl_id < 0) return false;
+			H5D_layout_t layout = H5Pget_layout(dcpl_id);
+			H5Pclose(dcpl_id);
+			return layout == H5D_CHUNKED;
+		}();
+		if( use_pipeline ){
 			const h5::block_t& block = arg::get( h5::default_block, args...);
 			const h5::offset_t& offset = arg::get( h5::default_offset, args...);
 			const h5::stride_t& stride = arg::get( h5::default_stride, args...);

--- a/h5cpp/H5Pdapl.hpp
+++ b/h5cpp/H5Pdapl.hpp
@@ -12,22 +12,41 @@
 		inline herr_t dapl_pipeline_close( const char *name, size_t size, void *ptr ){
 			(void)name; (void)size;
 			delete *static_cast< impl::pipeline_t<impl::basic_pipeline_t>**>( ptr );
-		return 0;
+			return 0;
+		}
+		// Copy callback for the high_throughput pipeline property.
+		//
+		// HDF5 ≥ 1.10.7 internally copies the DAPL when an object (dataset, file,
+		// attribute) is opened or created against it, so the object can carry its
+		// own DAPL.  Without a copy callback, the property's bytes (the 8-byte
+		// pipeline pointer) are memcpy'd verbatim — leaving both the user's DAPL
+		// and HDF5's internal copy holding the same pipeline pointer.  When each
+		// DAPL is later destroyed, dapl_pipeline_close fires on the same pointer
+		// twice → double-free.  This is the root cause of the historic "crashes
+		// on 1.12.x" TODO.  See issue #242.
+		//
+		// Fresh-allocation semantics are correct here because the pipeline is
+		// per-write scratch state, not shared accumulating state — set_cache()
+		// runs on every H5Dopen and on every h5::write/h5::read call.
+		inline herr_t dapl_pipeline_copy( const char *name, size_t size, void *value ){
+			(void)name; (void)size;
+			using pipeline = impl::pipeline_t<impl::basic_pipeline_t>;
+			*static_cast<pipeline**>(value) = new pipeline();
+			return 0;
 		}
 		inline ::herr_t dapl_pipeline_set(::hid_t dapl ) {
-			(void)dapl;
-		//TODO: see why H5CPP pipeline crashes with 1.12.x
-#if H5_VERSION_LE(1,10,6) 
-		// ignore if already set 
-		if( H5Pexist(dapl, H5CPP_DAPL_HIGH_THROUGHPUT) ) return 0;
-		using pipeline = impl::pipeline_t<impl::basic_pipeline_t>;
-	 	pipeline* ptr = new pipeline();
-		return H5Pinsert2(dapl, H5CPP_DAPL_HIGH_THROUGHPUT, sizeof( pipeline* ), &ptr,
-				nullptr, nullptr, nullptr, nullptr, nullptr, dapl_pipeline_close);
-#else
-			return 0;
-#endif
-	}
+			// ignore if already set
+			if( H5Pexist(dapl, H5CPP_DAPL_HIGH_THROUGHPUT) ) return 0;
+			using pipeline = impl::pipeline_t<impl::basic_pipeline_t>;
+			pipeline* ptr = new pipeline();
+			return H5Pinsert2(dapl, H5CPP_DAPL_HIGH_THROUGHPUT, sizeof( pipeline* ), &ptr,
+				nullptr,                  // set
+				nullptr,                  // get
+				nullptr,                  // prp_del
+				dapl_pipeline_copy,       // copy — issue #242 fix
+				nullptr,                  // compare
+				dapl_pipeline_close);
+		}
 }
 
 namespace h5 {

--- a/test/H5Pall.cpp
+++ b/test/H5Pall.cpp
@@ -1,7 +1,12 @@
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include <doctest/all>
 #include <h5cpp/core>
+#include <h5cpp/io>
 #include <h5cpp/H5Pall.hpp>
+#include <atomic>
+#include <unordered_set>
+#include <vector>
+#include "support/fixture.hpp"
 
 TEST_CASE("instantiate commonly used property types") {
     h5::chunk c{10};
@@ -51,4 +56,145 @@ TEST_CASE("instantiate dead gcpl property types") {
 TEST_CASE("property types can be daisy-chained with operator|") {
     h5::dcpl_t props = h5::chunk{10} | h5::gzip{6} | h5::flag::fletcher32{};
     CHECK(static_cast<hid_t>(props) > 0);
+}
+
+// =====================================================================
+// [#242] DAPL high_throughput pipeline lifecycle — regression guard
+// =====================================================================
+//
+// HDF5 ≥ 1.10.7 internally copies the DAPL during H5Dopen / H5Dcreate so the
+// dataset owns its own.  Without a copy callback on the high_throughput
+// property, both the user's DAPL and HDF5's internal copy hold the same
+// pipeline pointer → close callback fires twice on the same pointer →
+// double-free.  The fix in H5Pdapl.hpp adds dapl_pipeline_copy that allocates
+// a fresh pipeline for the destination DAPL.
+//
+// This test installs a tracking close-callback (count invocations, verify each
+// pointer freed exactly once) directly via H5Pinsert2, exercises an open/close
+// cycle, and asserts no pointer is freed more than once.
+namespace h5_242_regression {
+    using pipeline = h5::impl::pipeline_t<h5::impl::basic_pipeline_t>;
+    inline std::atomic<int> allocations{0};
+    inline std::atomic<int> deletions{0};
+    inline std::unordered_set<void*>& live_pointers() {
+        static std::unordered_set<void*> s;
+        return s;
+    }
+    inline std::atomic<bool> double_free_detected{false};
+
+    inline herr_t tracking_close_cb(const char*, size_t, void* ptr) {
+        auto* stored = *static_cast<pipeline**>(ptr);
+        auto& live = live_pointers();
+        auto it = live.find(stored);
+        if (it == live.end()) {
+            double_free_detected.store(true);
+            return -1;
+        }
+        live.erase(it);
+        deletions.fetch_add(1);
+        delete stored;
+        return 0;
+    }
+    inline herr_t tracking_copy_cb(const char*, size_t, void* value) {
+        auto** ptr_loc = static_cast<pipeline**>(value);
+        auto* fresh = new pipeline();
+        live_pointers().insert(fresh);
+        allocations.fetch_add(1);
+        *ptr_loc = fresh;
+        return 0;
+    }
+
+    inline h5::dapl_t make_tracked_dapl(bool with_copy_cb) {
+        hid_t raw = H5Pcreate(H5P_DATASET_ACCESS);
+        auto* p = new pipeline();
+        live_pointers().insert(p);
+        allocations.fetch_add(1);
+        H5Pinsert2(raw, "h5cpp_dapl_highthroughput",
+                   sizeof(pipeline*), &p,
+                   nullptr, nullptr, nullptr,
+                   with_copy_cb ? tracking_copy_cb : nullptr,
+                   nullptr, tracking_close_cb);
+        return h5::dapl_t{raw};
+    }
+
+    inline void reset_counters() {
+        allocations.store(0);
+        deletions.store(0);
+        live_pointers().clear();
+        double_free_detected.store(false);
+    }
+}
+
+TEST_CASE("[#242] regression scaffold — test fails when copy-cb is omitted") {
+    // Sanity check on the test itself: install the property WITHOUT a copy
+    // callback (the broken pre-fix state) and confirm our tracking close-cb
+    // detects the double-free. Guards against silent test breakage where the
+    // assertion becomes a no-op.
+    using namespace h5_242_regression;
+    reset_counters();
+
+    {
+        h5::test::file_fixture_t f("test-pdapl-242-scaffold.h5");
+        h5::dapl_t my_dapl = make_tracked_dapl(/*with_copy_cb=*/false);
+        {
+            h5::ds_t ds = h5::create<int>(f.fd, "ds", h5::current_dims_t{0},
+                h5::max_dims_t{H5S_UNLIMITED}, h5::chunk{16}, my_dapl);
+            (void)ds;
+        }
+    }
+
+    // Without copy-cb the close-cb fires twice on the same pointer.
+    CHECK(double_free_detected.load());
+    // Reset state so subsequent tests start clean.
+    reset_counters();
+}
+
+TEST_CASE("[#242] high_throughput pipeline survives open/close without double-free") {
+    using namespace h5_242_regression;
+    reset_counters();
+
+    {
+        h5::test::file_fixture_t f("test-pdapl-242.h5");
+        h5::dapl_t my_dapl = make_tracked_dapl(/*with_copy_cb=*/true);
+        // Open/close cycle — HDF5 copies the DAPL into the dataset, then destroys
+        // the copy on H5Dclose, firing the close-cb on the COPY's pipeline pointer.
+        {
+            h5::ds_t ds = h5::create<int>(f.fd, "ds", h5::current_dims_t{0},
+                h5::max_dims_t{H5S_UNLIMITED}, h5::chunk{16}, my_dapl);
+            (void)ds;
+        }
+        // my_dapl destructs at end of scope, firing close-cb on the USER's pointer.
+    }
+
+    CHECK(!double_free_detected.load());
+    // Each allocation (user + each copy) was freed exactly once.
+    CHECK(allocations.load() == deletions.load());
+    CHECK(live_pointers().empty());
+    CHECK(allocations.load() >= 1);   // at least the user's pipeline existed
+}
+
+TEST_CASE("[#242] high_throughput round-trip end-to-end via h5::write / h5::read") {
+    using namespace h5_242_regression;
+    reset_counters();
+
+    constexpr int N = 128;
+    std::vector<int> expected(N);
+    for (int i = 0; i < N; ++i) expected[i] = i * 7 + 3;
+
+    {
+        h5::test::file_fixture_t f("test-pdapl-242-rt.h5");
+        h5::dapl_t my_dapl = make_tracked_dapl(/*with_copy_cb=*/true);
+        h5::ds_t ds = h5::create<int>(f.fd, "ds", h5::current_dims_t{N},
+            h5::max_dims_t{H5S_UNLIMITED}, h5::chunk{32}, my_dapl);
+        h5::write(ds, expected.data(), h5::count{N});
+    }
+    {
+        h5::fd_t fd = h5::open("test-pdapl-242-rt.h5", H5F_ACC_RDONLY);
+        auto readback = h5::read<std::vector<int>>(fd, "ds");
+        REQUIRE(readback.size() == expected.size());
+        CHECK(readback == expected);
+    }
+    CHECK(!double_free_detected.load());
+    CHECK(allocations.load() == deletions.load());
+    CHECK(live_pointers().empty());
 }

--- a/test/win_h5dwrite_path_probe.cpp
+++ b/test/win_h5dwrite_path_probe.cpp
@@ -155,7 +155,12 @@ namespace {
             h5::dapl_t dapl = h5::high_throughput;
             std::vector<double> data{1.0, 2.0, 3.0};
             probe("fd_object_high_throughput_dapl: before h5::write(fd, path, vector, high_throughput)");
-            h5::write(fd, "vec", data, h5::current_dims{3}, dapl);
+            // h5::chunk{3} is required: the high_throughput pipeline uses
+            // H5Dwrite_chunk, which only operates on chunked datasets. Pre-#242
+            // the pipeline path was a no-op on HDF5 ≥ 1.10.7 so this call
+            // silently fell back to standard H5Dwrite. With the pipeline now
+            // active, the chunk specifier is mandatory.
+            h5::write(fd, "vec", data, h5::current_dims{3}, h5::chunk{3}, dapl);
             probe("fd_object_high_throughput_dapl: after h5::write(fd, path, vector, high_throughput)");
         }
         remove_file(path);


### PR DESCRIPTION
Resolves #242.

Fixes the double-free that caused the long-standing "crashes with 1.12.x" TODO
and disabled the entire `high_throughput` pipeline path on HDF5 ≥ 1.10.7 via
`H5_VERSION_LE(1,10,6)` gating in `H5Pdapl.hpp`.

## Root cause

HDF5 ≥ 1.10.7 internally copies the DAPL when an object (dataset, file,
attribute) is opened against it. Without a copy callback on the
`H5CPP_DAPL_HIGH_THROUGHPUT` property, the 8-byte pipeline pointer is
memcpy'd verbatim — both the user's DAPL and HDF5's internal copy hold the
same pointer. When each DAPL is later destroyed, `dapl_pipeline_close` fires
on the same pointer twice → double-free.

Reproducer with a tracking close-cb on HDF5 1.10.9:

```
[setup] allocated pipeline=0x...1b0
[step 2] dataset created
[close-cb #1] property close, ptr=0x...1b0 (== tracked)   ← H5Dclose
[step 3] file closed
[close-cb #2] property close, ptr=0x...1b0 (== tracked)   ← user-DAPL destruction
```

Two close-cb invocations on identical pointer.

## Fix

Add `dapl_pipeline_copy` callback that allocates a fresh pipeline for each
destination property list, so each DAPL copy owns its own pipeline:

```cpp
inline herr_t dapl_pipeline_copy(const char*, size_t, void* value) {
    using pipeline = impl::pipeline_t<impl::basic_pipeline_t>;
    *static_cast<pipeline**>(value) = new pipeline();
    return 0;
}
```

Fresh-allocation is correct because the pipeline is per-write scratch state,
not shared accumulating state — `set_cache()` runs on every `H5Dopen` and on
every `h5::write` / `h5::read` entry point.

`H5_VERSION_LE(1,10,6)` gate removed; the path activates on all supported
HDF5 versions.

## Test plan

- [x] `cmake -B build -DH5CPP_BUILD_TESTS=ON && cmake --build build -j` clean.
- [x] `ctest --output-on-failure` — 50/50 pass; no regressions.
- [x] New `[#242]` test cases in `test/H5Pall.cpp`:
  - **Regression scaffold** — installs the property WITHOUT the copy-cb (the
    broken pre-fix state) and asserts the tracking close-cb sees a double-free.
    Guards against silent test breakage where the assertion becomes a no-op.
  - **Pipeline survives open/close without double-free** — installs WITH
    copy-cb, exercises an `H5Dcreate` / `H5Dclose` cycle, asserts each
    allocated pipeline is freed exactly once.
  - **End-to-end via h5::write / h5::read** — writes 128 ints through the
    now-enabled pipeline path, reads back, verifies content and bookkeeping.

## Unblocks

- Threaded `h5::write` opt-in via `h5::filter::threads{N}` (#241 phase 2)
- Threaded `h5::read` decompression parallelism (#241 phase 3)
- Any future user of `pipeline_t<>::write()` / `pipeline_t<>::read()` through
  the DAPL mechanism

## What did *not* change

- `pt_t` packet-table path (already independent — owns its pipeline directly)
- Public API surface — `h5::high_throughput` was always exposed; this only
  fixes its behavior on modern HDF5
- File format on disk — pure runtime/lifecycle fix