### PR TITLE
[#245+#246+#247+#248]:svarga:fix, v1.12.5 packaging workflow remediation and README cleanup

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -86,10 +86,12 @@ jobs:
 
       - name: Configure
         run: |
+          HDF5_PREFIX="$(brew --prefix hdf5)"
           cmake -B build \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INSTALL_PREFIX=/usr/local \
-            -DHDF5_ROOT=$(brew --prefix hdf5) \
+            -DHDF5_ROOT="$HDF5_PREFIX" \
+            -DCMAKE_PREFIX_PATH="$HDF5_PREFIX" \
             -DH5CPP_BUILD_EXAMPLES=OFF \
             -DH5CPP_BUILD_TESTS=OFF \
             -DH5CPP_BUILD_BENCH=OFF
@@ -107,21 +109,100 @@ jobs:
           if-no-files-found: error
 
   # ── Windows (NSIS .exe) ───────────────────────────────────────────────────────
+  # No Chocolatey 'hdf5' package exists; mirror the build-from-source approach
+  # from ci.yml.  zlib is built fresh each run (~30s); HDF5 install prefix is
+  # cached between runs.
   package-windows:
     name: windows / x64 / NSIS
     runs-on: windows-latest
+    env:
+      HDF5_VERSION: 1.12.2
+      HDF5_CACHE_VERSION: v3
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install HDF5
-        run: choco install hdf5 -y --no-progress
+      - name: Build zlib from source
+        shell: powershell
+        run: |
+          $ErrorActionPreference = "Stop"
+          $zlib_version = "1.3.1"
+          $zlib_archive = "$env:RUNNER_TEMP\zlib-$zlib_version.tar.gz"
+          $zlib_source  = "$env:RUNNER_TEMP\zlib-$zlib_version"
+          $zlib_build   = "$env:RUNNER_TEMP\zlib-build"
+          $zlib_prefix  = "$env:RUNNER_TEMP\zlib-install"
+
+          Invoke-WebRequest `
+            -Uri "https://github.com/madler/zlib/archive/refs/tags/v$zlib_version.tar.gz" `
+            -OutFile $zlib_archive
+          tar -xzf $zlib_archive -C $env:RUNNER_TEMP
+
+          cmake -S $zlib_source -B $zlib_build `
+            -G "Visual Studio 17 2022" -A x64 `
+            -DCMAKE_INSTALL_PREFIX="$zlib_prefix"
+          cmake --build $zlib_build --parallel --config Release
+          cmake --install $zlib_build --config Release
+
+      - name: Restore HDF5 cache
+        id: cache-hdf5
+        uses: actions/cache/restore@v5
+        with:
+          path: ${{ runner.temp }}\hdf5-${{ env.HDF5_VERSION }}-install
+          key: hdf5-windows-vs2022-${{ env.HDF5_VERSION }}-pkg-${{ env.HDF5_CACHE_VERSION }}
+
+      - name: Build HDF5 from source
+        if: steps.cache-hdf5.outputs.cache-hit != 'true'
+        shell: powershell
+        run: |
+          $ErrorActionPreference = "Stop"
+          $hdf5_version = "${{ env.HDF5_VERSION }}"
+          $hdf5_archive = "$env:RUNNER_TEMP\hdf5-$hdf5_version.tar.gz"
+          $hdf5_source  = "$env:RUNNER_TEMP\hdf5-$hdf5_version"
+          $hdf5_build   = "$env:RUNNER_TEMP\hdf5-$hdf5_version-build"
+          $hdf5_prefix  = "$env:RUNNER_TEMP\hdf5-$hdf5_version-install"
+
+          Invoke-WebRequest `
+            -Uri "https://support.hdfgroup.org/ftp/HDF5/releases/hdf5-1.12/hdf5-$hdf5_version/src/hdf5-$hdf5_version.tar.gz" `
+            -OutFile $hdf5_archive
+          tar -xzf $hdf5_archive -C $env:RUNNER_TEMP
+
+          cmake -S $hdf5_source -B $hdf5_build `
+            -G "Visual Studio 17 2022" -A x64 `
+            -DCMAKE_INSTALL_PREFIX="$hdf5_prefix" `
+            -DHDF_CFG_NAME=Release `
+            -DBUILD_SHARED_LIBS=ON `
+            -DBUILD_TESTING=OFF `
+            -DHDF5_BUILD_TOOLS=OFF `
+            -DHDF5_BUILD_UTILS=OFF `
+            -DHDF5_BUILD_EXAMPLES=OFF `
+            -DHDF5_BUILD_CPP_LIB=OFF `
+            -DHDF5_BUILD_HL_LIB=OFF `
+            -DHDF5_BUILD_FORTRAN=OFF `
+            -DHDF5_ENABLE_Z_LIB_SUPPORT=ON `
+            -DHDF5_ENABLE_SZIP_SUPPORT=OFF `
+            -DZLIB_USE_EXTERNAL=OFF `
+            -DZLIB_INCLUDE_DIR="$env:RUNNER_TEMP/zlib-install/include" `
+            -DZLIB_LIBRARY="$env:RUNNER_TEMP/zlib-install/lib/zlib.lib"
+
+          cmake --build $hdf5_build --parallel --config Release
+          cmake --install $hdf5_build --config Release
+
+      - name: Save HDF5 cache
+        if: steps.cache-hdf5.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: ${{ runner.temp }}\hdf5-${{ env.HDF5_VERSION }}-install
+          key: ${{ steps.cache-hdf5.outputs.cache-primary-key }}
 
       - name: Configure
         shell: pwsh
         run: |
+          $hdf5_prefix = "$env:RUNNER_TEMP/hdf5-${{ env.HDF5_VERSION }}-install"
+          $zlib_prefix = "$env:RUNNER_TEMP/zlib-install"
           cmake -B build `
             -DCMAKE_BUILD_TYPE=Release `
+            -DHDF5_ROOT="$hdf5_prefix" `
+            -DCMAKE_PREFIX_PATH="$hdf5_prefix;$zlib_prefix" `
             -DH5CPP_BUILD_EXAMPLES=OFF `
             -DH5CPP_BUILD_TESTS=OFF `
             -DH5CPP_BUILD_BENCH=OFF `

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,24 @@ if(APPLE)
     set(CMAKE_OSX_DEPLOYMENT_TARGET "14.4" CACHE STRING "Minimum macOS deployment version")
 endif()
 
-project(libh5cpp-dev VERSION 1.10.4.6 LANGUAGES CXX C)
+# Derive package version from the latest git tag before project(), so CPack
+# embeds it as PROJECT_VERSION rather than a stale hardcoded number.  Falls
+# back to a placeholder when building from a tarball without git history.
+find_package(Git QUIET)
+set(H5CPP_PROJECT_VERSION "1.12.0")
+if(GIT_FOUND AND EXISTS "${CMAKE_SOURCE_DIR}/.git")
+    execute_process(
+        COMMAND ${GIT_EXECUTABLE} describe --tags --abbrev=0 --match "v[0-9]*"
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        OUTPUT_VARIABLE H5CPP_GIT_TAG
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET)
+    if(H5CPP_GIT_TAG MATCHES "^v([0-9]+(\\.[0-9]+)*)$")
+        set(H5CPP_PROJECT_VERSION "${CMAKE_MATCH_1}")
+    endif()
+endif()
+
+project(libh5cpp-dev VERSION ${H5CPP_PROJECT_VERSION} LANGUAGES CXX C)
 
 # ─── Standard Settings ────────────────────────────────────────────────────────────
 set(CMAKE_CXX_STANDARD 20)
@@ -90,9 +107,15 @@ find_package(Threads REQUIRED QUIET)
 # ─── HDF5 ─────────────────────────────────────────────────────────────────────────
 find_package(HDF5 REQUIRED COMPONENTS C)
 
-if(HDF5_VERSION VERSION_LESS ${H5CPP_BASE_VERSION})
+# HDF5 floor is decoupled from h5cpp package version.  Previously the check
+# compared HDF5_VERSION against PROJECT_VERSION, which coupled package
+# versioning to HDF5 minimums by coincidence.  After #234 raised the floor
+# to 1.12 and #247 made PROJECT_VERSION track the git tag, the comparison
+# stopped being meaningful.  Pin the floor explicitly.
+set(H5CPP_HDF5_FLOOR "1.12.0")
+if(HDF5_VERSION VERSION_LESS ${H5CPP_HDF5_FLOOR})
     message(FATAL_ERROR
-        "-- !!! H5CPP examples require HDF5 v${H5CPP_BASE_VERSION} or greater !!!"
+        "-- !!! H5CPP requires HDF5 v${H5CPP_HDF5_FLOOR} or greater (found ${HDF5_VERSION}) !!!"
     )
 else()
     message(STATUS
@@ -381,6 +404,14 @@ set(CPACK_NSIS_ENABLE_UNINSTALL_BEFORE_INSTALL ON)
 
 # productbuild (macOS .pkg)
 set(CPACK_PRODUCTBUILD_IDENTIFIER     "org.h5cpp.h5cpp")
+
+# Override the default per-generator filename so that amd64 / arm64 / x86_64 /
+# aarch64 / darwin-arm64 / windows-amd64 produce distinct names when collected
+# into a single release upload directory.  Without this, multi-arch CI matrix
+# builds emit identical filenames and overwrite each other on the Release page.
+set(CPACK_PACKAGE_FILE_NAME
+    "${CPACK_PACKAGE_NAME}-v${PROJECT_VERSION}-${CMAKE_SYSTEM_NAME}-${CMAKE_SYSTEM_PROCESSOR}")
+string(TOLOWER "${CPACK_PACKAGE_FILE_NAME}" CPACK_PACKAGE_FILE_NAME)
 
 include(CPack)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20123216.svg)](https://doi.org/10.5281/zenodo.20123216)
 [![GitHub release](https://img.shields.io/github/v/release/vargalabs/h5cpp.svg)](https://github.com/vargalabs/h5cpp/releases)
 [![Documentation](https://img.shields.io/badge/docs-stable-blue)](https://vargalabs.github.io/h5cpp)
-[![Downloads](https://img.shields.io/github/downloads/vargalabs/h5cpp/total)](https://github.com/vargalabs/h5cpp/releases)
 
 # H5CPP — High-Performance [HDF5][hdf5] for Modern C++
 


### PR DESCRIPTION
Bundles the four v1.12.5 packaging and docs fixes filed after the v1.12.4
Package workflow failed on macOS and Windows.

Resolves #245, #246, #247, #248.

## Commits

| SHA | Issue | Change |
|---|---|---|
| \`0cfe520a\` | #248 | \`docs, remove Downloads count badge from README\` |
| \`9abd0ddc\` | #247 | \`fix, derive CPack version from git tag and add arch to filename\` |
| \`5162dc87\` | #245, #246 | \`fix, package.yml macOS HDF5 discovery + Windows build-from-source\` |

(\`5162dc87\` bundles #245 and #246 because both are in the same workflow file
and tightly related. CONTRIBUTING.md prefers commit-per-issue; here the
co-location and shared rationale justified the bundling.)

## What this unblocks

When tagged as v1.12.5, the Package workflow should produce assets across
all four platforms (Linux amd64/arm64, macOS arm64, Windows x64) with
clean naming. The Publish job will then upload all of them automatically
to the v1.12.5 GitHub Release — no manual rename + upload step needed
this time.

## Test plan

Local:

- [x] \`cmake -B build\` parses CMakeLists.txt cleanly with the new git-tag
      derivation logic; HDF5 floor check now reads from H5CPP_HDF5_FLOOR
      (\`1.12.0\`) rather than PROJECT_VERSION (correctly rejects the
      developer's local 1.10.9 with the new message).
- [x] \`.github/workflows/package.yml\` parses as valid YAML; jobs and
      steps in the Windows section are in correct order (zlib → cache
      restore → conditional HDF5 build → cache save → Configure →
      Build → Package → upload-artifact).

Remote (via CI on this PR):

- [ ] Linux amd64: DEB + RPM produced with new filenames
      \`h5cpp-dev-v<version>-linux-x86_64.{deb,rpm}\`
- [ ] Linux arm64: DEB + RPM produced with new filenames
      \`h5cpp-dev-v<version>-linux-aarch64.{deb,rpm}\`
- [ ] macOS arm64: \`.pkg\` produced (FindHDF5 succeeds with both
      HDF5_ROOT and CMAKE_PREFIX_PATH set)
- [ ] Windows x64: NSIS \`.exe\` produced (zlib + HDF5 1.12.2 built
      from source; cached for subsequent runs)

## After merge

Tag v1.12.5 from \`release\` once promoted from \`staging\`. The Package
workflow on the tag should populate \`v1.12.5\` with all six assets
automatically.

## Note on the version-derivation regex

\`git describe --tags --abbrev=0 --match 'v[0-9]*'\` returns the latest
reachable matching tag from HEAD. The regex \`^v([0-9]+(\\\\.[0-9]+)*)$\`
deliberately rejects tags with non-numeric suffixes like \`v1.10.4-6\`
so they fall back to the placeholder \`1.12.0\`. On release-branch
builds at a v1.12.x tag, the actual tag string is captured. On staging
or feature-branch builds where v1.12.x is not yet reachable, the
placeholder is used — acceptable for development; only the
release-branch tag-build matters for shipped artifacts.