### PR TITLE
[#289]:svarga:fix, H5CPP_supported_elementary_types redefined with conflicting values (~50 build warnings)

### DIFF
--- a/h5cpp/H5Tmeta.hpp
+++ b/h5cpp/H5Tmeta.hpp
@@ -26,8 +26,12 @@
 #include <cstring>
 #include <utility>
 
-//FIXME: move it elsewhere
-#define H5CPP_supported_elementary_types "supported elementary types ::= pod_struct | float | double |  [signed](int8 | int16 | int32 | int64)"
+// H5CPP_supported_elementary_types is defined once in H5misc.hpp (the
+// canonical copy that includes `enum`); H5misc is always pulled in ahead of
+// this header via h5cpp/core, and the macro is only consumed by the
+// static_assert diagnostics in H5Dread/H5Dwrite. The duplicate definition
+// that used to live here conflicted with H5misc's and produced a redefinition
+// warning in every TU including core (#289).
 
 // stl detection with templates, this probably should stay until concepts become mainstream
 namespace h5::meta {


### PR DESCRIPTION
Closes #289.

## Problem
`H5CPP_supported_elementary_types` was `#define`d twice with conflicting values — `H5misc.hpp:22` (current, includes `enum`) and `H5Tmeta.hpp:30` (stale, `//FIXME: move it elsewhere`, missing `enum`). Both are pulled in by `h5cpp/core`, so every TU including core emitted a redefinition warning (~50 across the test build, visible on CDash). The stale copy also won (included last), dropping `enum` from the diagnostic even though enums are supported.

## Fix
Removed the stale duplicate from `H5Tmeta.hpp`, leaving the single canonical definition in `H5misc.hpp`. The macro is only consumed by the static_assert diagnostics in `H5Dread`/`H5Dwrite`, which always include `H5misc` via core — so no functional change.

## Verification
Syntax-check of a TU including `<h5cpp/core>` + `<h5cpp/io>`: **0** `redefined` warnings (was firing before), compiles clean.