### PR TITLE
[#295]:svarga:build, honor CMP0074 so examples find_package respects HDF5_ROOT

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -7,6 +7,13 @@ cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 ## match hdf5 versioning x.x.x.h5cpp-version
 project(h5cpp-examples VERSION 1.10.4.5 LANGUAGES CXX C)
 
+# Honor <PackageName>_ROOT (CMP0074, CMake 3.12+). The cmake_minimum_required
+# above predates it, so without this find_package(HDF5) below would silently
+# ignore the HDF5_ROOT we build for custom HDF Group installs. (#295)
+if(POLICY CMP0074)
+	cmake_policy(SET CMP0074 NEW)
+endif()
+
 # check if the correct version of hdf5 available
 set(H5CPP_VERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH})
 


### PR DESCRIPTION
Closes #295.

## Problem
A CMake dev warning at configure (surfaced by the `BUILD_EXAMPLES=ON` default, #278):
```
CMake Warning (dev) at examples/CMakeLists.txt:27 (find_package):
  Policy CMP0074 is not set ... CMake is ignoring the variable HDF5_ROOT
```
`examples/CMakeLists.txt` declares `cmake_minimum_required(VERSION 3.10)`, which predates CMP0074 (3.12). Under that baseline the policy defaults to OLD, so `find_package(HDF5)` ignores the `HDF5_ROOT` the file builds (lines 20-25) for custom HDF Group installs — the discovery logic was silently inert.

## Fix
`cmake_policy(SET CMP0074 NEW)` after `project()` (guarded with `if(POLICY ...)`).

## Verification
Configure with `HDF5_ROOT` set: **0** CMP0074 warnings, **0** CMake warnings, HDF5 found, no "ignoring the variable" message.